### PR TITLE
Fix Issue #9 - locale.firstDay support.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -122,12 +122,14 @@
                 this.endDate = Date.parse(options.endDate, this.format);
 
             // update day names order to firstDay
-            if (typeof options.locale.firstDay == 'number') {
-                this.locale.firstDay = options.locale.firstDay;
-                var iterator = options.locale.firstDay;
-                while (iterator > 0) {
-                    this.locale.daysOfWeek.push(this.locale.daysOfWeek.shift());
-                    iterator--;
+            if (typeof options.locale == 'object') {
+                if (typeof options.locale.firstDay == 'number') {
+                    this.locale.firstDay = options.locale.firstDay;
+                    var iterator = options.locale.firstDay;
+                    while (iterator > 0) {
+                        this.locale.daysOfWeek.push(this.locale.daysOfWeek.shift());
+                        iterator--;
+                    }
                 }
             }
 


### PR DESCRIPTION
- [FIX] When no locale object is passed in 
  (it's optional), the DRP does not work at all
- [FIX] You modify options.locale instead of 
  this.locale
- [FIX] The firstDay property should be part of
  the locale object
- [FiX] When firstDay is not 0, even after 
  correcting for the above issues, correct 
  calendars are no longer produced for
  all months/years
