### PR TITLE
Improve the jQuery function

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -432,7 +432,8 @@
     $.fn.daterangepicker = function (options, cb) {
       this.each(function() {
         var el = $(this);
-        el.data('daterangepicker', new DateRangePicker(el, options, cb));
+        if (!el.data('daterangepicker'))
+          el.data('daterangepicker', new DateRangePicker(el, options, cb));
       });
       return this;
     };


### PR DESCRIPTION
This does the following things:
- Returns `this` to conform to jQuery standards to allow chaining.
- Creates one daterangepicker for each element passed in.
- Stores the daterangepicker in the element's `data-daterangepicker` attribute.
- Don't create multiple daterangepickers on the same element
