### PR TITLE
Month names localization fix

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -458,7 +458,7 @@
             {
                  html += '<th></th>';
             }
-            html += '<th colspan="5">' + calendar[1][1].toString("MMMM yyyy") + '</th>';
+            html += '<th colspan="5">' + this.locale.monthNames[calendar[1][1].getMonth()] + calendar[1][1].toString(" yyyy") + '</th>';
             if (!maxDate || maxDate > calendar[1][1])
             {
                 html += '<th class="next available"><i class="icon-arrow-right"></i></th>';


### PR DESCRIPTION
locale.monthNames wasn't being used to display month names.
