### PR TITLE
Enables the date range selected to be limited to a set time frame

### DIFF
--- a/daterangeLimitexamples.html
+++ b/daterangeLimitexamples.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en-US">
+   <head>
+      <meta charset="UTF-8" />
+      <title>A date range picker for Twitter Bootstrap</title>
+      <link rel="stylesheet" type="text/css" media="all" href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" />
+      <link rel="stylesheet" type="text/css" media="all" href="daterangepicker.css" />
+      <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+      <script type="text/javascript" src="date.js"></script>
+      <script type="text/javascript" src="daterangepicker.js"></script>
+   </head>
+   <body>
+
+      <div class="container">
+         <div class="span12">
+
+             <h4>Simple Example with date range limited to 1 month</h4>
+             <p>This example only allows dates to be a max of a month apart. </p>
+				<p>If the end date is more than a month past the start date when selecting the start date, the end date is set to a months time</p>
+				<p>If the start date is more than a month before the end date when selecting the end date, the start date is set to a month ago</p>
+				<p>Uses the date.js <a href="http://code.google.com/p/datejs/wiki/APIDocumentation#add">config settings</a><br />
+					<code>
+					$('#booking').daterangepicker(
+							{
+								dateLimit: { months: 1 }
+							});
+				   </code>
+				</p>
+            <div class="well">
+
+               <form class="form-horizontal">
+                 <fieldset>
+                  <div class="control-group">
+                    <label class="control-label" for="reservation">Reservation dates:</label>
+                    <div class="controls">
+                     <div class="input-prepend">
+                       <span class="add-on"><i class="icon-calendar"></i></span><input type="text" name="reservation" id="reservation" />
+                     </div>
+                    </div>
+                  </div>
+                 </fieldset>
+               </form>
+
+               <script type="text/javascript">
+               $(document).ready(function() {
+                   $('#reservation').daterangepicker(
+                             {
+                                 dateLimit: { months: 1 }
+                             });
+               });
+               </script>
+
+            </div>
+             </div>
+      </div>
+
+   </body>
+</html>

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -19,6 +19,7 @@
         this.maxDate = false;
         this.changed = false;
         this.ranges = {};
+        this.dateLimit = false;
         this.opens = 'right';
         this.cb = function () { };
         this.format = 'MM/dd/yyyy';
@@ -169,6 +170,9 @@
                 list += '</ul>';
                 this.container.find('.ranges').prepend(list);
             }
+            
+            if (typeof options.dateLimit == 'object')
+                this.dateLimit = options.dateLimit;
 
             // update day names order to firstDay
             if (typeof options.locale == 'object') {
@@ -412,9 +416,26 @@
             if (cal.hasClass('left')) {
                 startDate = this.leftCalendar.calendar[row][col];
                 endDate = this.endDate;
+                if (typeof this.dateLimit == 'object') {
+                    var maxDate = new Date(startDate).add(this.dateLimit);
+                    if (endDate.isAfter(maxDate)) {
+                        endDate = maxDate;
+                    }
+                }
             } else {
                 startDate = this.startDate;
                 endDate = this.rightCalendar.calendar[row][col];
+                if (typeof this.dateLimit == 'object') {
+                    var negConfig = {
+                        days: 0 - this.dateLimit.days,
+                        months: 0 - this.dateLimit.months,
+                        years: 0 - this.dateLimit.years
+                    };
+                    var minDate = new Date(endDate).add(negConfig);
+                    if (startDate.isBefore(minDate)) {
+                        startDate = minDate;
+                    }
+                }
             }
 
             cal.find('td').removeClass('active');


### PR DESCRIPTION
Uses the date.js config settings
$('#booking').daterangepicker( { dateLimit: { months: 1 } });

Fixed issue with my fork of the repository and used the latest code base to make the changed.

related to issue #22
