### PR TITLE
Add 'clear' functionality, range highlighting, auto-apply, and event triggers

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -18,6 +18,7 @@
         this.minDate = false;
         this.maxDate = false;
         this.changed = false;
+        this.cleared = false;
         this.ranges = {};
         this.opens = 'right';
         this.cb = function () { };
@@ -27,8 +28,11 @@
         this.buttonClasses = ['btn-success'];
         this.locale = {
             applyLabel: 'Apply',
+            clearLabel:"Clear",
             fromLabel: 'From',
+            fromCalLabel:"From",
             toLabel: 'To',
+            toCalLabel:"To",
             weekLabel: 'W',
             customRangeLabel: 'Custom Range',
             daysOfWeek: Date.CultureInfo.shortestDayNames,
@@ -79,15 +83,16 @@
                 '<div class="calendar right"></div>' +
                 '<div class="ranges">' +
                   '<div class="range_inputs">' +
-                    '<div>' +
+                    '<div class="daterangepicker_start_input" style="float: left">' +
                       '<label for="daterangepicker_start">' + this.locale.fromLabel + '</label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_start" value="" disabled="disabled" />' +
                     '</div>' +
-                    '<div>' +
+                    '<div class="daterangepicker_end_input" style="float: left; padding-left: 11px">' +
                       '<label for="daterangepicker_end">' + this.locale.toLabel + '</label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_end" value="" disabled="disabled" />' +
                     '</div>' +
-                    '<button class="btn btn-small" disabled="disabled">' + this.locale.applyLabel + '</button>' +
+                    '<button class="btn btn-small btn-success applyBtn" disabled="disabled">' + this.locale.applyLabel + '</button>&nbsp;' +
+                    '<button class="btn btn-small clearBtn">' + this.locale.clearLabel + '</button>' +
                   '</div>' +
                 '</div>' +
               '</div>';
@@ -225,7 +230,8 @@
         this.container.on('mousedown', $.proxy(this.mousedown, this));
         this.container.find('.calendar').on('click', '.prev', $.proxy(this.clickPrev, this));
         this.container.find('.calendar').on('click', '.next', $.proxy(this.clickNext, this));
-        this.container.find('.ranges').on('click', 'button', $.proxy(this.clickApply, this));
+        this.container.find('.ranges').on('click', 'button.applyBtn', $.proxy(this.clickApply, this));
+        this.container.find('.ranges').on('click', 'button.clearBtn', $.proxy(this.clickClear, this));
 
         this.container.find('.calendar').on('click', 'td.available', $.proxy(this.clickDate, this));
         this.container.find('.calendar').on('mouseenter', 'td.available', $.proxy(this.enterDate, this));
@@ -259,9 +265,9 @@
             this.container.find('input[name=daterangepicker_end]').val(this.endDate.toString(this.format));
 
             if (this.startDate.equals(this.endDate) || this.startDate.isBefore(this.endDate)) {
-                this.container.find('button').removeAttr('disabled');
+                this.container.find('button.applyBtn').removeAttr('disabled');
             } else {
-                this.container.find('button').attr('disabled', 'disabled');
+                this.container.find('button.applyBtn').attr('disabled', 'disabled');
             }
         },
 
@@ -284,12 +290,17 @@
         },
 
         notify: function () {
-            this.updateView();
+            if (!this.cleared) {
+              this.updateView();
+            }
 
             if (this.element.is('input')) {
-                this.element.val(this.startDate.toString(this.format) + this.separator + this.endDate.toString(this.format));
+                this.element.val(this.cleared ? '' : this.startDate.toString(this.format) + this.separator + this.endDate.toString(this.format));
             }
-            this.cb(this.startDate, this.endDate);
+            var arg1 = (this.cleared ? null : this.startDate),
+                arg2 = (this.cleared ? null : this.endDate);
+            this.cleared = false;
+            this.cb(arg1,arg2);
         },
 
         move: function () {
@@ -322,6 +333,8 @@
             }
 
             this.changed = false;
+            
+            this.element.trigger('shown',{target:e.target,picker:this});
 
             $(document).on('mousedown', $.proxy(this.hide, this));
         },
@@ -412,9 +425,17 @@
             if (cal.hasClass('left')) {
                 startDate = this.leftCalendar.calendar[row][col];
                 endDate = this.endDate;
+                this.element.trigger('clicked',{
+                  dir: 'left',
+                  picker: this
+                });
             } else {
                 startDate = this.startDate;
                 endDate = this.rightCalendar.calendar[row][col];
+                this.element.trigger('clicked',{
+                  dir: 'right',
+                  picker: this
+                });
             }
 
             cal.find('td').removeClass('active');
@@ -426,21 +447,37 @@
                 this.startDate = startDate;
                 this.endDate = endDate;
             }
+            else if (startDate.isAfter(endDate)) {
+                $(e.target).addClass('active');
+                this.changed = true;
+                this.startDate = startDate;
+                this.endDate = startDate.clone().add(2).days();
+            }
 
             this.leftCalendar.month.set({ month: this.startDate.getMonth(), year: this.startDate.getFullYear() });
             this.rightCalendar.month.set({ month: this.endDate.getMonth(), year: this.endDate.getFullYear() });
             this.updateCalendars();
+            if (cal.hasClass('right')) {
+              this.hide();
+            }
         },
 
         clickApply: function (e) {
             this.hide();
         },
 
+        clickClear: function (e) {
+            this.changed = true;
+            this.cleared = true;
+            this.hide();
+        },
+
         updateCalendars: function () {
             this.leftCalendar.calendar = this.buildCalendar(this.leftCalendar.month.getMonth(), this.leftCalendar.month.getFullYear());
             this.rightCalendar.calendar = this.buildCalendar(this.rightCalendar.month.getMonth(), this.rightCalendar.month.getFullYear());
-            this.container.find('.calendar.left').html(this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.endDate));
-            this.container.find('.calendar.right').html(this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.startDate, this.maxDate));
+            this.container.find('.calendar.left').html('<b class="calendar-label">' + this.locale.fromCalLabel + '</b>' + this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.maxDate));
+            this.container.find('.calendar.right').html('<b class="calendar-label">' + this.locale.toCalLabel + '</b>' + this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.startDate, this.maxDate));
+            this.element.trigger('updated',this);
         },
 
         buildCalendar: function (month, year) {
@@ -539,15 +576,23 @@
 
                     if ( (minDate && calendar[row][col] < minDate) || (maxDate && calendar[row][col] > maxDate))
                     {
-                        cname = 'off disabled';
+                        cname = ' off disabled ';
                     }
                     else if (calendar[row][col].equals(selected))
                     {
-                        cname += 'active';
+                        cname += ' active ';
+                        if (calendar[row][col].equals(this.startDate)) { cname += ' start-date '; }
+                        if (calendar[row][col].equals(this.endDate)) { cname += ' end-date '; }
+                    }
+                    else if (calendar[row][col] >= this.startDate && calendar[row][col] <= this.endDate)
+                    {
+                        cname += ' in-range ';
+                        if (calendar[row][col].equals(this.startDate)) { cname += ' start-date '; }
+                        if (calendar[row][col].equals(this.endDate)) { cname += ' end-date '; }
                     }
                     
                     var title = 'r' + row + 'c' + col;
-                    html += '<td class="' + cname + '" title="' + title + '">' + calendar[row][col].getDate() + '</td>';
+                    html += '<td class="' + cname.replace(/\s+/g,' ').replace(/^\s?(.*?)\s?$/,'$1') + '" title="' + title + '">' + calendar[row][col].getDate() + '</td>';
                 }
                 html += '</tr>';
             }


### PR DESCRIPTION
Add 'Clear' butotn and functionality to calendar
Separate calendar labels from field labels
Add some event triggers (eg. shown, clicked, updated) for users to listen for
Auto-apply/close when right calendar (TO date) is updated
Allow start date AFTER end date to be selected (automatically choose new end date 2 days after new start)
Allow highlighting of selected date ranges
