### PR TITLE
Change move function so that it does not adjust according to the scrollbar

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -48,9 +48,6 @@
             calendar: Array()
         };
 
-        // by default, the daterangepicker element is placed at the bottom of HTML body
-        this.parentEl = 'body';
-
         //element that triggered the date range picker
         this.element = $(element);
 
@@ -92,9 +89,7 @@
                 '</div>' +
               '</div>';
 
-        this.parentEl = (hasOptions && options.parentEl && $(options.parentEl)) || $(this.parentEl);
-        //the date range picker
-        this.container = $(DRPTemplate).appendTo(this.parentEl);
+        this.container = $(DRPTemplate).appendTo('body');
 
         if (hasOptions) {
 
@@ -293,20 +288,16 @@
         },
 
         move: function () {
-            var parentOffset = {
-                top: this.parentEl.offset().top - this.parentEl.scrollTop(),
-                left: this.parentEl.offset().left - this.parentEl.scrollLeft()
-            };
             if (this.opens == 'left') {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
-                    right: $(window).width() - this.element.offset().left - this.element.outerWidth() - parentOffset.left,
+                    top: this.element.offset().top + this.element.outerHeight(),
+                    right: $(window).width() - this.element.offset().left - this.element.outerWidth(),
                     left: 'auto'
                 });
             } else {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
-                    left: this.element.offset().left - parentOffset.left,
+                    top: this.element.offset().top + this.element.outerHeight(),
+                    left: this.element.offset().left,
                     right: 'auto'
                 });
             }


### PR DESCRIPTION
Someone had changed the move function so that the calendar position adjusted depending on scroll. This led to the calendar appearing in the middle of the page instead of directly under the element it was connected to. This patch is correcting that move function.
