### PR TITLE
fix dropdown behaviours and add a new setting for them

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -20,6 +20,7 @@
         this.changed = false;
         this.cleared = false;
         this.showDropdowns = false;
+        this.dropdownAdjusts = false;
         this.ranges = {};
         this.dateLimit = false;
         this.opens = 'right';
@@ -211,6 +212,10 @@
             
             if (typeof options.showDropdowns == 'boolean') {
                 this.showDropdowns = options.showDropdowns;
+            }
+
+            if (typeof options.dropdownAdjusts == 'boolean') {
+                this.dropdownAdjusts = options.dropdownAdjusts;
             }
 
         }
@@ -516,6 +521,10 @@
             var isLeft = $(e.target).closest('.calendar').hasClass('left');
             var calendar = isLeft ? this.leftCalendar : this.rightCalendar;
             calendar.month.set({ month: calendar.month.getMonth(), year: year});
+            if (this.dropdownAdjusts) {
+              this[isLeft ? 'startDate' : 'endDate'].set({year:year});
+              this.changed = true;
+            }
             this.updateCalendars();
         },
         
@@ -524,6 +533,10 @@
             var isLeft = $(e.target).closest('.calendar').hasClass('left');
             var calendar = isLeft ? this.leftCalendar : this.rightCalendar;
             calendar.month.set({ month: month, year: calendar.month.getFullYear()});
+            if (this.dropdownAdjusts) {
+              this[isLeft ? 'startDate' : 'endDate'].set({month:month});
+              this.changed = true;
+            }
             this.updateCalendars();
         },
 


### PR DESCRIPTION
the original implementation was forcing the month to start/end date
month when the user changed the year, or the year to start/end date year
if the user changed the month. That meant that if the user were to first
change the year then the month (or other way around) the dropdown
changed first would jump back to what it was.

this implementation keeps "the other dropdown" in its current state.

plus **a new setting** for dropdown mode - `dropdownAdjusts`.

when this setting is `false` (default) selecting new month/year from the
dropdowns doesn't change currently selected range. this is the original
behavior and corresponds to how next/previous buttons work.

We've found however that in some cases users are more comfortable
adjusting the year (or month) and clicking 'apply' - e.g. when most of
the time ranges are from 1st of the month till end of another month.
That's the behavior when this setting is `true`.
