### PR TITLE
Changing the year/month with the dropdown doesn't reinitialize the month/year

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -516,9 +516,9 @@
             var isLeft = $(e.target).closest('.calendar').hasClass('left');
 
             if(isLeft) {
-                this.leftCalendar.month.set({ month: this.startDate.getMonth(), year: year });
+                this.leftCalendar.month.set({ month: this.leftCalendar.month.getMonth(), year: year });
             } else {
-                this.rightCalendar.month.set({ month: this.endDate.getMonth(), year: year });
+                this.rightCalendar.month.set({ month: this.rightCalendar.month.getMonth(), year: year });
             }
 
             this.updateCalendars();
@@ -529,9 +529,9 @@
             var isLeft = $(e.target).closest('.calendar').hasClass('left');
 
             if(isLeft) {
-                this.leftCalendar.month.set({ month: month, year: this.startDate.getFullYear() });
+                this.leftCalendar.month.set({ month: month, year: this.leftCalendar.month.getFullYear() });
             } else {
-                this.rightCalendar.month.set({ month: month, year: this.endDate.getFullYear() });
+                this.rightCalendar.month.set({ month: month, year: this.rightCalendar.month.getFullYear() });
             }
 
             this.updateCalendars();


### PR DESCRIPTION
### This is the issue I'm fixing:

Let's say you start at March 2013. You change the month to September, it is now September 2013. Now, if you change the year to 2010, the month will get reset to March (March 2010). If you change the month back to September, the year gets reset to 2013.

Basically, you can only choose between changing the month "xor" the year. This pull request corrects this.
