### PR TITLE
Suggestion: use css class to show/hide calendars

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -30,6 +30,10 @@
   max-width: 230px;
 }
 
+.daterangepicker.show-calendars .calendar {
+  display: block;
+}
+
 .daterangepicker .calendar th, .daterangepicker .calendar td {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   white-space: nowrap;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -415,7 +415,7 @@
         clickRange: function (e) {
             var label = e.target.innerHTML;
             if (label == this.locale.customRangeLabel) {
-                this.container.find('.calendar').show();
+                this.container.addClass('show-calendars');
                 this.move();
             } else {
                 var dates = this.ranges[label];
@@ -429,7 +429,7 @@
 
                 this.changed = true;
 
-                this.container.find('.calendar').hide();
+                this.container.removeClass('show-calendars');
                 this.move();
                 this.hide();
             }


### PR DESCRIPTION
It is useful for our app's styles to know when calendars are shown or
not so we can apply older browser fixes in css. This patch allows that. 

Other possible uses: implementing CSS transitions for showing / hiding calendars if desired.
