### PR TITLE
Make the picker responsive

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -31,12 +31,19 @@
 }
 
 /* ranges + (calendar * 2) = 160 + (230 *2 ) = 620 */
+@media (min-width: 620px) {
+  .daterangepicker.opensright .calendar { float: left !important; }
+}
 @media (max-width: 619px) {
     .daterangepicker.dropdown-menu { max-width: 496px !important; }
     .daterangepicker.opensleft .ranges { float: right !important; }
+
+    .daterangepicker.opensright .calendar.left { float: left; !important; }
+    .daterangepicker.opensright .calendar.right { float: right; !important; }
 }
 @media (max-width: 495px) {
     .daterangepicker.dropdown-menu { max-width: 240px !important; }
+    .daterangepicker.opensright .calendar { float: left !important; }
     .daterangepicker.opensright .ranges { float: left !important; }
 }
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -226,14 +226,6 @@
             c.find('button').addClass(val);
         });
 
-        if (this.opens == 'right') {
-            //swap calendar positions
-            var left = this.container.find('.calendar.left');
-            var right = this.container.find('.calendar.right');
-            left.removeClass('left').addClass('right');
-            right.removeClass('right').addClass('left');
-        }
-
         if (typeof options == 'undefined' || typeof options.ranges == 'undefined') {
             this.container.find('.calendar').show();
             this.move();


### PR DESCRIPTION
I've done the most minimal change I could find to make the picker responsive.
When the display window is smaller than the width of all three calendar
elements then they'll be stacked as needed.

![Preview image](http://i.imgur.com/lpuaEwn.png)
