### PR TITLE
Fix TypeError message: moment(...) is null

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -323,6 +323,7 @@
 
         updateFromControl: function () {
             if (!this.element.is('input')) return;
+            if (!this.element.val().length) return;
 
             var dateString = this.element.val().split(this.separator);
             var start = moment(dateString[0], this.format).startOf('day');


### PR DESCRIPTION
Avoiding TypeError message when the input field is empty and some key (like Backspace) is pressed.
