### PR TITLE
Fix range not being applied on click

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -443,6 +443,7 @@
                 this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year()).hour(this.startDate.hour()).minute(this.startDate.minute());
                 this.rightCalendar.month.month(this.endDate.month()).year(this.endDate.year()).hour(this.endDate.hour()).minute(this.endDate.minute());
                 this.updateCalendars();
+                this.clickApply();
 
                 this.container.find('.calendar').hide();
                 this.hide();


### PR DESCRIPTION
When clicking on a range we are hiding the range picker but not applying it. This patch applies the date as well.
