### PR TITLE
clicking on range_inputs area shows the calendar

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -25,7 +25,7 @@
         this.timePicker = false;
         this.timePickerIncrement = 30;
         this.timePicker12Hour = true;
-        this.ranges = {};        
+        this.ranges = {};
         this.opens = 'right';
 
         this.buttonClasses = ['btn', 'btn-small'];
@@ -291,6 +291,7 @@
         this.container.find('.ranges').on('click', 'li', $.proxy(this.clickRange, this));
         this.container.find('.ranges').on('mouseenter', 'li', $.proxy(this.enterRange, this));
         this.container.find('.ranges').on('mouseleave', 'li', $.proxy(this.updateView, this));
+        this.container.find('.ranges').on('click', '.range_inputs div', $.proxy(this.showCalendar, this));
 
         this.container.find('.calendar').on('change', 'select.yearselect', $.proxy(this.updateYear, this));
         this.container.find('.calendar').on('change', 'select.monthselect', $.proxy(this.updateMonth, this));
@@ -385,6 +386,11 @@
                     });
                 }
             }
+        },
+
+        showCalendar: function () {
+            this.container.find('.calendar').show();
+            this.move();
         },
 
         show: function (e) {
@@ -532,7 +538,7 @@
 
         clickApply: function (e) {
             if (this.element.is('input'))
-                this.element.val(this.startDate.format(this.format) + this.separator + this.endDate.format(this.format));            
+                this.element.val(this.startDate.format(this.format) + this.separator + this.endDate.format(this.format));
             this.hide();
         },
 
@@ -595,7 +601,7 @@
                 var end = this.endDate;
                 end.hour(hour);
                 end.minute(minute);
-                this.endDate = end;              
+                this.endDate = end;
                 this.rightCalendar.month.hour(hour).minute(minute);
             }
 


### PR DESCRIPTION
Thanks for your awesome plugin!

Our users have asked that clicking on the range inputs should bring up the calendar (in addition to clicking on the 'Custom Range' li). We can modify this pull request if there's a better way of implementing this that we missed, just let us know. (Also, our text editors removed some whitespace automatically.)

Thanks so much!
