### PR TITLE
Bug fixing - wrong calculation of the calendar position

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -360,8 +360,8 @@
             }
             if (this.opens == 'left') {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight(false),
-                    right: $(window).width() - this.element.offset().left - this.element.outerWidth(false),
+                    top: this.element.offset().top + this.element.outerHeight(true),
+                    right: $(window).width() - this.element.offset().left - this.element.outerWidth(true),
                     left: 'auto',
                     'min-width': minWidth
                 });
@@ -373,12 +373,12 @@
                 }
             } else {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight(false),
+                    top: this.element.offset().top + this.element.outerHeight(true),
                     left: this.element.offset().left,
                     right: 'auto',
                     'min-width': minWidth
                 });
-                if (this.container.offset().left + this.container.outerWidth(false) > $(window).width()) {
+                if (this.container.offset().left + this.container.outerWidth(true) > $(window).width()) {
                     this.container.css({
                         left: 'auto',
                         right: 0


### PR DESCRIPTION
function (this.elements.outerHeight () incorrectly calculates the calendar position and returns [object Object]

http://bugs.jquery.com/ticket/12491
http://bugs.jquery.com/ticket/12159
