### PR TITLE
default range length

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -19,6 +19,7 @@
         this.minDate = false;
         this.maxDate = false;
         this.dateLimit = false;
+        this.defaultRangeLength = 1;
 
         this.showDropdowns = false;
         this.showWeekNumbers = false;
@@ -532,7 +533,7 @@
             } else if (startDate.isAfter(endDate)) {
                 $(e.target).addClass('active');
                 this.startDate = startDate;
-                this.endDate = moment(startDate).add('day', 1).startOf('day');
+                this.endDate = moment(startDate).add('day', this.defaultRangeLength).startOf('day');
             }
 
             this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year());

--- a/examples.html
+++ b/examples.html
@@ -23,7 +23,7 @@
                     <label class="control-label" for="reservation">Reservation dates:</label>
                     <div class="controls">
                      <div class="input-prepend">
-                       <span class="add-on"><i class="glyphicon glyphicon-calendar icon-calendar"></i></span><input type="text" style="width: 200px" name="reservation" id="reservation" value="03/18/2013 - 03/23/2013" /> 
+                       <span class="add-on"><i class="glyphicon glyphicon-calendar icon-calendar"></i></span><input type="text" style="width: 200px" name="reservation" id="reservation" value="03/18/2013 - 03/23/2013" />
                      </div>
                     </div>
                   </div>
@@ -65,7 +65,7 @@
                });
                </script>
 
-            </div>            
+            </div>
 
             <h4>Options Usage Example</h4>
 
@@ -84,6 +84,7 @@
                         endDate: moment(),
                         minDate: '01/01/2012',
                         maxDate: '12/31/2014',
+                        defaultRangeLength: 2,
                         dateLimit: { days: 60 },
                         showDropdowns: true,
                         showWeekNumbers: true,


### PR DESCRIPTION
added the option to define a range length.

this can be convenient for daterange pickers defining a departure date: having the default range length set to 0 the daterangepicker initially acts like a regular date picker and a range becomes optional… 
