### PR TITLE
Update daterange picker's values after component is created.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -844,17 +844,42 @@
 
             return html;
 
-        }
-
+        },
+		updateDates: function (options) {
+			if (typeof options.startDate !== 'object') {
+				return;
+			}
+			if (typeof options.endDate !== 'object') {
+				return;
+			}
+			this.startDate = moment(options.startDate, this.format).startOf('day');
+			this.endDate = moment(options.endDate, this.format).endOf('day');
+			this.updateView();
+			this.updateCalendars();
+		}
     };
 
-    $.fn.daterangepicker = function (options, cb) {
-        this.each(function () {
-            var el = $(this);
-            if (!el.data('daterangepicker'))
-                el.data('daterangepicker', new DateRangePicker(el, options, cb));
-        });
-        return this;
-    };
-
+	$.fn.daterangepicker = function (options, cb) {
+		this.each(function () {
+			var el = $(this);
+			if (!el.data('daterangepicker')) {
+				el.data('daterangepicker', new DateRangePicker(el, options, cb));
+			}
+			/*Extension of component*/
+			else {
+				if (typeof options == 'object') {
+					if (options.action !== undefined) {
+						switch (options.action) {
+							case 'update':
+								var dp = el.data('daterangepicker');
+								dp.updateDates(options);
+								break;
+						}
+					}
+				}
+			}
+			/*End of the extension of component*/
+		});
+		return this;
+	};
 }(window.jQuery);


### PR DESCRIPTION
In come cases selected values should be changed after component is initialized.
As I see it's impossible to implement such behavior. But it's a good point of extension.
Code for update is base on the comments of the bootstrap-daterangepicker users.
