### PR TITLE
set z index of rangepicker to a higher number, so as to be above eg bootstrap-modal

### DIFF
--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -10,6 +10,7 @@
 
 .daterangepicker.dropdown-menu {
   max-width: none;
+  z-index: 3000;
 }
 
 .daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar {

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -10,6 +10,7 @@
 
  .daterangepicker.dropdown-menu {
   max-width: none;
+  z-index: 3000;
 }
 
 .daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar {


### PR DESCRIPTION
currently, when the daterange picker is placed in a modal which uses a z-index, the range picker is behind the modal.
for example:
http://i.imgur.com/gOicNHt.png

in this instance, i was using bootstrap-modal which has a z-index of 1050.

when making the z-index 3000, i was then able to see the dropdown:
http://i.imgur.com/X7do1iT.png
