### PR TITLE
Fix a incorrect behavior in calendar generation in chrome in brazilian daylight saving start day (e.g. 2013-10-19)

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -664,7 +664,7 @@
                 startDay = daysInLastMonth - 6;
 
             var curDate = moment([lastYear, lastMonth, startDay, 12, minute]);
-            for (var i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add('day', 1)) {
+            for (var i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add('hour', 24)) {
                 if (i > 0 && col % 7 == 0) {
                     col = 0;
                     row++;


### PR DESCRIPTION
Due the ECMAScript 5.1 daylight savings specification [1], Google Chrome V8 js engine starts the first day of brazilian daylight saving at 11:00 PM instead 00:00 AM (only happens when using brazilian timezone in SO):

``` javascript
>> new Date(2013, 9, 19)
Sat Oct 19 2013 00:00:00 GMT-0300 (BRT)

>> new Date(2013, 9, 20)
Sat Oct 19 2013 23:00:00 GMT-0300 (BRT)
```

It makes the moment `add('day', 1)` function call return a incorrect result [2]:

``` javascript
>> moment('2013-10-19').add('day', 1).toDate()
Sat Oct 19 2013 00:00:00 GMT-0300 (BRT)
```

Then the bootstrap-daterangepicker generate a calendar with a duplicated day (search for day 20):
![bootstrap-daterangepicker-error](https://f.cloud.github.com/assets/496987/1256436/3c5405c4-2b95-11e3-8c5d-b7da638cbebd.png)

This wrong behavior can be avoided adding 24 hours to get the next day instead adding 1 day in calendar generation loop.

[1] http://codeofmatt.com/2013/06/07/javascript-date-type-is-horribly-broken/
[2] https://github.com/moment/moment/issues/1069
