### PR TITLE
Update daterangepicker.js

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -594,13 +594,13 @@
             }
 
             if (isLeft) {
-                var start = this.startDate;
+                var start = this.startDate.clone();
                 start.hour(hour);
                 start.minute(minute);
                 this.startDate = start;
                 this.leftCalendar.month.hour(hour).minute(minute);
             } else {
-                var end = this.endDate;
+                var end = this.endDate.clone();
                 end.hour(hour);
                 end.minute(minute);
                 this.endDate = end;


### PR DESCRIPTION
fix for messing time in custom predefined ranges

I've had such a case:

I had predefined ranges for last 12 or 24 hours. And it was working fine, but then when I clicked custom range, and changed the hour for one side it has changed my predefined range and it wasn't last 12 hours anymore. cloning the date fixed it for me
