### PR TITLE
Suggestion: Only trigger notify if there is an actual change

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -347,10 +347,15 @@
             if (start == null || end == null) return;
             if (end.isBefore(start)) return;
 
+            this.oldStartDate = this.startDate.clone();
+            this.oldEndDate = this.endDate.clone();
+
             this.startDate = start;
             this.endDate = end;
 
-            this.notify();
+            if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
+                this.notify();
+
             this.updateCalendars();
         },
 


### PR DESCRIPTION
I noticed the change callback firing without the daterange being changed. 

The callback method fires on every keyup (line 310) regardless of any actual change. E.G. pressing the SHIFT, CTRL or other modifier key will trigger the callback. This makes it difficult to do certain things in the callback... like auto-submitting the form for example.

Please review if a change like this is suitable.

(The implementation is copied from the hide method)
