### PR TITLE
Fix month dropdown compatibility with newest moment.js. Fixes #181

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -560,7 +560,8 @@
             if (!isLeft)
                 cal = this.container.find('.calendar.right');
 
-            var month = cal.find('.monthselect').val();
+            // Month must be Number for new moment versions
+            var month = parseInt(cal.find('.monthselect').val(), 10);
             var year = cal.find('.yearselect').val();
 
             if (isLeft) {


### PR DESCRIPTION
Looks like the newest moment version does a naive month parse that doesn't detect input such as `"6"`, interpreting its String type to mean that it must be a month abbreviation like `"Jun"`. 

This PR simply makes sure that we pass a Number type to that method, fixing the month dropdowns.
