### PR TITLE
Clone daysOfWeek only if locale option was set

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -179,15 +179,15 @@
 
             // update day names order to firstDay
             if (typeof options.locale == 'object') {
-                if (typeof options.locale.firstDay == 'number') {
+
+                if (typeof options.locale.daysOfWeek == 'object') {
 
                     // Create a copy of daysOfWeek to avoid modification of original
                     // options object for reusability in multiple daterangepicker instances
-                    this.locale.daysOfWeek = [];
-                    for ( var i = 0; i < options.locale.daysOfWeek.length; i++) {
-                        this.locale.daysOfWeek.push(options.locale.daysOfWeek[i]);
-                    }
+                    this.locale.daysOfWeek = options.locale.daysOfWeek.slice();
+                }
 
+                if (typeof options.locale.firstDay == 'number') {
                     this.locale.firstDay = options.locale.firstDay;
                     var iterator = options.locale.firstDay;
                     while (iterator > 0) {


### PR DESCRIPTION
As mentioned in another issue, this causes an error if firstDay is set but daysOfWeek is not. Fixed and tested, sorry for that. Cloning a bit more elegant now, too.
