### PR TITLE
Reset feature to set start and end date to original values 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "bootstrap-daterangepicker-reset",
-  "version": "1.0.0",
+  "name": "bootstrap-daterangepicker",
+  "version": "1.2.0",
   "main": "daterangepicker.js",
   "ignore": [
     "**/.*",

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -757,7 +757,7 @@
                 html += '<th></th>';
 
             if (!minDate || minDate.isBefore(calendar[1][1])) {
-                html += '<th class="prev available"><i class="icon-arrow-left glyphicon glyphicon-arrow-left"></i></th>';
+                html += '<th class="prev available"><i class="fa fa-arrow-left icon-arrow-left glyphicon glyphicon-arrow-left"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -770,7 +770,7 @@
 
             html += '<th colspan="5" style="width: auto">' + dateHtml + '</th>';
             if (!maxDate || maxDate.isAfter(calendar[1][1])) {
-                html += '<th class="next available"><i class="icon-arrow-right glyphicon glyphicon-arrow-right"></i></th>';
+                html += '<th class="next available"><i class="fa fa-arrow-right icon-arrow-right glyphicon glyphicon-arrow-right"></i></th>';
             } else {
                 html += '<th></th>';
             }


### PR DESCRIPTION
We added in a reset button next to the cancel button that, when clicked, will set the start and end date values back to what the control(s) initialized with.  To accomodate this, we resized the overall control by adding 50px to its width. 
