### PR TITLE
Always fire notify fix

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -360,8 +360,7 @@
             this.startDate = start;
             this.endDate = end;
 
-            if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
-                this.notify();
+            this.notify();
 
             this.updateCalendars();
         },
@@ -419,8 +418,7 @@
         hide: function (e) {
             this.container.hide();
 
-            if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
-                this.notify();
+            this.notify();
 
             this.oldStartDate = this.startDate.clone();
             this.oldEndDate = this.endDate.clone();


### PR DESCRIPTION
This would fix a state where `notify()` fires only if the range is present. If there is no range present ( same day selected ) or `cancel` has been clicked no notification would be send.

``` js
$('input[name="daterange"]').daterangepicker({ format: 'YYYY-MM-DD', startDate: '2013-01-01', endDate: '2013-12-31' }, function notify(start, end) { 
   console.log('A date range was chosen: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD'));
});
```
