### PR TITLE
Move inline styles to css

### DIFF
--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -237,3 +237,16 @@
   width: 60px;
   margin-bottom: 0;
 }
+
+.daterangepicker_start_input {
+  float: left;
+}
+
+.daterangepicker_end_input {
+  float: left; 
+  padding-left: 11px
+}
+
+th.Year {
+  width: auto;
+}

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -247,3 +247,16 @@
   width: 50px;
   margin-bottom: 0;
 }
+
+.daterangepicker_start_input {
+  float: left;
+}
+
+.daterangepicker_end_input {
+  float: left; 
+  padding-left: 11px
+}
+
+th.Year {
+  width: auto;
+}

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -22,11 +22,11 @@
                 '<div class="calendar right"></div>' +
                 '<div class="ranges">' +
                   '<div class="range_inputs">' +
-                    '<div class="daterangepicker_start_input" style="float: left">' +
+                    '<div class="daterangepicker_start_input">' +
                       '<label for="daterangepicker_start"></label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_start" value="" disabled="disabled" />' +
                     '</div>' +
-                    '<div class="daterangepicker_end_input" style="float: left; padding-left: 11px">' +
+                    '<div class="daterangepicker_end_input">' +
                       '<label for="daterangepicker_end"></label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_end" value="" disabled="disabled" />' +
                     '</div>' +
@@ -807,7 +807,7 @@
                 dateHtml = this.renderDropdowns(calendar[1][1], minDate, maxDate);
             }
 
-            html += '<th colspan="5" style="width: auto">' + dateHtml + '</th>';
+            html += '<th colspan="5" class="Year">' + dateHtml + '</th>';
             if (!maxDate || maxDate.isAfter(calendar[1][1])) {
                 html += '<th class="next available"><i class="fa fa-arrow-right icon-arrow-right glyphicon glyphicon-arrow-right"></i></th>';
             } else {


### PR DESCRIPTION
Move inline styles to css in order to prevent CSP (Content Security
Policy) warnings
