### PR TITLE
Persisting selected end time when switching to a later start date.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -640,8 +640,9 @@
                 this.endDate = endDate;
             } else if (startDate.isAfter(endDate)) {
                 $(e.target).addClass('active');
+                var difference = this.endDate.diff(this.startDate);
                 this.startDate = startDate;
-                this.endDate = moment(startDate).add('day', 1).startOf('day');
+                this.endDate = moment(startDate).add('ms', difference);
             }
 
             this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year());


### PR DESCRIPTION
Keeps the users end time selected instead of defaulting to 12AM the next day when a user chooses a later start date.
