### PR TITLE
Make endDate represent the end of the chosen date/range

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -99,7 +99,7 @@
         setOptions: function(options, callback) {
 
             this.startDate = moment().startOf('day');
-            this.endDate = moment().startOf('day');
+            this.endDate = moment().endOf('day');
             this.minDate = false;
             this.maxDate = false;
             this.dateLimit = false;
@@ -321,7 +321,7 @@
 
             if (!this.timePicker) {
                 this.startDate = this.startDate.startOf('day');
-                this.endDate = this.endDate.startOf('day');
+                this.endDate = this.endDate.endOf('day');
             }
 
             if (this.singleDatePicker) {
@@ -393,7 +393,7 @@
                 this.endDate = moment(endDate);
 
             if (!this.timePicker)
-                this.endDate = this.endDate.startOf('day');
+                this.endDate = this.endDate.endOf('day');
 
             this.oldEndDate = this.endDate.clone();
 
@@ -557,7 +557,7 @@
 
                 if (!this.timePicker) {
                     this.startDate.startOf('day');
-                    this.endDate.startOf('day');
+                    this.endDate.endOf('day');
                 }
 
                 this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year()).hour(this.startDate.hour()).minute(this.startDate.minute());
@@ -635,9 +635,9 @@
             }
 
             if (this.singleDatePicker && cal.hasClass('left')) {
-                endDate = startDate;
+                endDate = startDate.clone();
             } else if (this.singleDatePicker && cal.hasClass('right')) {
-                startDate = endDate;
+                startDate = endDate.clone();
             }
 
             cal.find('td').removeClass('active');
@@ -656,6 +656,8 @@
             this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year());
             this.rightCalendar.month.month(this.endDate.month()).year(this.endDate.year());
             this.updateCalendars();
+
+            endDate.endOf('day');
 
             if (this.singleDatePicker)
                 this.clickApply();

--- a/examples.html
+++ b/examples.html
@@ -80,7 +80,7 @@
                     <div class="controls">
                      <div class="input-prepend input-group">
                        <span class="add-on input-group-addon"><i class="glyphicon glyphicon-calendar fa fa-calendar"></i></span>
-                       <input type="text" style="width: 300px" name="reservation" id="reservationtime" class="form-control" value="08/01/2013 1:00 PM - 08/01/2013 1:30 PM"  class="span4"/>
+                       <input type="text" style="width: 400px" name="reservation" id="reservationtime" class="form-control" value="08/01/2013 1:00 PM - 08/01/2013 1:30 PM"  class="span4"/>
                      </div>
                     </div>
                   </div>


### PR DESCRIPTION
Make `endDate` represent the end of the chosen date/range, rather the start of the last day

The input values and formatted moment (like what `alert` showed in the example) remain unchanged, but the actual moment in the callback for endDate represents the "end of the day" rather than the "start of the day". That way when a day or range is selected `startDate` represents the true moment in time from the beginning of the day/range, and `endDate` represents the true moment in time for the end of the day/range.

I can explain further why I think this makes sense, if you're unsure about this change
