### PR TITLE
Plays nicely with Bootstrap dropdowns

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -7,6 +7,7 @@
       <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css" rel="stylesheet">
       <link rel="stylesheet" type="text/css" media="all" href="daterangepicker-bs3.css" />
       <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+      <script type="text/javascript" src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
       <script type="text/javascript" src="moment.js"></script>
       <script type="text/javascript" src="daterangepicker.js"></script>
    </head>
@@ -200,6 +201,33 @@
                </script>
 
             </div>
+
+
+            <h4>Plays nicely with Bootstrap dropdowns</h4>
+
+            <div class="well">
+
+               <div class="dropdown" style="display: inline-block;">
+                 <a data-toggle="dropdown" class="btn btn-primary" href="#">Regular dropdown</a>
+                 <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+                   <li><a href="#">item</a></li>
+                 </ul>
+               </div>
+
+               <div id="reportrange2" class="btn" style="display: inline-block; background: #fff; cursor: pointer; padding: 5px 10px; border: 1px solid #ccc">
+                  <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>
+                  <span></span> <b class="caret"></b>
+               </div>
+
+               <script type="text/javascript">
+               $(document).ready(function() {
+                  $('#reportrange2 span').html(moment().subtract('days', 29).format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
+                  $('#reportrange2').daterangepicker();
+               });
+               </script>
+
+            </div>
+
 
          </div>
       </div>


### PR DESCRIPTION
Redo how daterangepicker is open/closed, fixing a couple problems.
- Allows clicking the trigger button/element to hide the picker (like regular bootstrap dropdowns)
- When a Bootstrap dropdown is open, clicking the daterangepicker element should close/hide the Bootstrap dropdown
- When a daterangepicker is open, clicking a Bootstrap dropdown element should close/hide the daterangepicker.

And I added some test UI to examples.html to make this easy to test.
