### PR TITLE
Handle empty initial range properly

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -575,7 +575,7 @@
                 this.updateInputText();
 
                 this.container.find('.calendar').hide();
-                this.hide(undefined, 'apply');
+                this.hide(e, 'apply');
                 this.element.trigger('apply.daterangepicker', this);
             }
         },
@@ -682,7 +682,7 @@
             this.chosenLabel = this.oldChosenLabel;
             this.updateView();
             this.updateCalendars();
-            this.hide(e, 'cancel');
+            this.hide();
             this.element.trigger('cancel.daterangepicker', this);
         },
 


### PR DESCRIPTION
When you start daterangepicker with no start/end dates set it takes current day as default - which is good. Problem rises when you try to stick with that "pre-selection" as your choice, clicking on apply or date (in single date picker mode) won't fire notify event - as it should in my opinion.

Those commits fix this situation for me.
