### PR TITLE
Fix 'chosenLabel' callback arg

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -662,11 +662,13 @@
                 $(e.target).addClass('active');
                 this.startDate = startDate;
                 this.endDate = endDate;
+                this.chosenLabel = this.locale.customRangeLabel;
             } else if (startDate.isAfter(endDate)) {
                 $(e.target).addClass('active');
                 var difference = this.endDate.diff(this.startDate);
                 this.startDate = startDate;
                 this.endDate = moment(startDate).add('ms', difference);
+                this.chosenLabel = this.locale.customRangeLabel;
             }
 
             this.leftCalendar.month.month(this.startDate.month()).year(this.startDate.year());


### PR DESCRIPTION
Make 'chosenLabel' callback arg correct when Custom was chosen without clicking 'Custom' range.

Fixes case where you click the date textboxes to open the calendars
rather than first clicking the word "Custom Range".

Fixup to 430a9607cde57afeafc27ef89410f762924eb571
