### PR TITLE
Check against element

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -40,7 +40,7 @@
         if (typeof options !== 'object' || options === null)
             options = {};
 
-        this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl)) || $(this.parentEl);
+        this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl).length) || $(this.parentEl);
         this.container = $(DRPTemplate).appendTo(this.parentEl);
 
         this.setOptions(options, cb);


### PR DESCRIPTION
What is `$(options.parentEl)` checking for?

I think it's should check that element exist? In that case it should check  jQuery selector `length`.
