### PR TITLE
Add support for RequireJS and other AMD loaders

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -6,7 +6,15 @@
 * @license: Licensed under Apache License v2.0. See http://www.apache.org/licenses/LICENSE-2.0
 * @website: http://www.improvely.com/
 */
-!function ($, moment) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module depending on jQuery.
+        define(['jquery', 'moment'], factory);
+    } else {
+        // No AMD. Register plugin with global jQuery object.
+        factory(window.jQuery, window.moment);
+    }
+}function ($, moment) {
 
     var DateRangePicker = function (element, options, cb) {
 
@@ -1003,4 +1011,4 @@
         return this;
     };
 
-}(window.jQuery, window.moment);
+}));


### PR DESCRIPTION
Related to Issue #278, here's a proposed fix that supports both AMD loaders and standard window-scoped variables.
