### PR TITLE
fix corrupt child nodes in IE9 and below

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -744,8 +744,8 @@
         updateCalendars: function () {
             this.leftCalendar.calendar = this.buildCalendar(this.leftCalendar.month.month(), this.leftCalendar.month.year(), this.leftCalendar.month.hour(), this.leftCalendar.month.minute(), 'left');
             this.rightCalendar.calendar = this.buildCalendar(this.rightCalendar.month.month(), this.rightCalendar.month.year(), this.rightCalendar.month.hour(), this.rightCalendar.month.minute(), 'right');
-            this.container.find('.calendar.left').html(this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.maxDate));
-            this.container.find('.calendar.right').html(this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.startDate, this.maxDate));
+            this.container.find('.calendar.left').empty().html(this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.maxDate));
+            this.container.find('.calendar.right').empty().html(this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.startDate, this.maxDate));
 
             this.container.find('.ranges li').removeClass('active');
             var customRange = true;


### PR DESCRIPTION
In IE9 and below, using `.html()` by itself to remove/update DOM structure will apparently break the removed child nodes to the point that things like `.closest()` no longer return any parent elements. This was resulting the `outerClick()` incorrectly hiding the datepicker for various cases. I'm just calling `.empty()` beforehand. The behavior is now corrected in my tests on IE9.

The [jQuery docs](https://api.jquery.com/html/#html2) say:

> In Internet Explorer up to and including version 9, setting the text content of an HTML element may corrupt the text nodes of its children that are being removed from the document as a result of the operation. If you are keeping references to these DOM elements and need them to be unchanged, use `.empty().html( string )` instead of `.html(string)` so that the elements are removed from the document before the new string is assigned to the element.

See https://github.com/dangrossman/bootstrap-daterangepicker/issues/275 for related discussion.
