### PR TITLE
Added events on show and hide of Calendars

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -546,10 +546,12 @@
         showCalendars: function() {
             this.container.addClass('show-calendar');
             this.move();
+            this.element.trigger('showCalendar.daterangepicker', this);
         },
 
         hideCalendars: function() {
             this.container.removeClass('show-calendar');
+            this.element.trigger('hideCalendar.daterangepicker', this);
         },
 
         updateInputText: function() {


### PR DESCRIPTION
Added events when showing and hiding the calendars. Use case : I added a range "forever" which set start and end to empty values. If user opens the picker again, and select "custom range", I want to set start and end to today. For example:

```
$('#datepicker').on('showCalendar.daterangepicker', function(event, picker) {
    var start = picker.startDate,
        end = picker.endDate;

    if(!start.isValid() && !end.isValid()) {
        $('#datepicker').data('daterangepicker').setEndDate(new Date());
        $('#datepicker').data('daterangepicker').setStartDate(new Date());
    }
});
```
