### PR TITLE
Don't set endDate time to endOf('day') if timePicker is on

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -675,7 +675,8 @@
             this.rightCalendar.month.month(this.endDate.month()).year(this.endDate.year());
             this.updateCalendars();
 
-            endDate.endOf('day');
+            if (!this.timePicker)
+                endDate.endOf('day');
 
             if (this.singleDatePicker)
                 this.clickApply();


### PR DESCRIPTION
I was surprised that if a user selects an endDate from the calendar **and do not touch the hour/minutes** then they are automatically set to 23:59.

It seems you have forgotten to only run `endDate.endOf('day')` if timePicker is disabled. It's now working as I expected.

Or maybe I'm missing something, am I ?
