### PR TITLE
fixed bug in setting the parent element correctly

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -40,7 +40,7 @@
         if (typeof options !== 'object' || options === null)
             options = {};
 
-        this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl).length) || $(this.parentEl);
+        this.parentEl = this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(DRPTemplate).appendTo(this.parentEl);
 
         this.setOptions(options, cb);


### PR DESCRIPTION
There's a bug in setting the parent element according to the options. When the parent element is provided in the options it is being set to 'true' instead of the actual element. 
