### PR TITLE
Made it possible to provide functions for start and end of a range.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -279,26 +279,31 @@
                 }
             }
 
-            if (typeof options.ranges === 'object') {
-                for (range in options.ranges) {
+            if (typeof options.ranges == 'object') {
+                for (var range in options.ranges) {
+                    var start;
+                    var end;
 
-                    start = moment(options.ranges[range][0]);
-                    end = moment(options.ranges[range][1]);
+                    if (typeof options.ranges[range][0] == 'function') {
+                        start = options.ranges[range][0];
+                    } else {
+                        start = moment(options.ranges[range][0]);
+                    }
 
-                    // If we have a min/max date set, bound this range
-                    // to it, but only if it would otherwise fall
-                    // outside of the min/max.
-                    if (this.minDate && start.isBefore(this.minDate))
-                        start = moment(this.minDate);
+                    if (typeof options.ranges[range][1] == 'function') {
+                        end = options.ranges[range][1];
+                    } else {
+                        end = moment(options.ranges[range][1]);
+                    }
 
-                    if (this.maxDate && end.isAfter(this.maxDate))
-                        end = moment(this.maxDate);
 
-                    // If the end of the range is before the minimum (if min is set) OR
-                    // the start of the range is after the max (also if set) don't display this
-                    // range option.
-                    if ((this.minDate && end.isBefore(this.minDate)) || (this.maxDate && start.isAfter(this.maxDate))) {
-                        continue;
+                    if (typeof start != 'function' && typeof end != 'function') {
+                        // If the end of the range is before the minimum (if min is set) OR
+                        // the start of the range is after the max (also if set) don't display this
+                        // range option.
+                        if ((this.minDate && end.isBefore(this.minDate)) || (this.maxDate && start.isAfter(this.maxDate))) {
+                            continue;
+                        }
                     }
 
                     this.ranges[range] = [start, end];
@@ -544,8 +549,17 @@
                 this.updateView();
             } else {
                 var dates = this.ranges[label];
-                this.container.find('input[name=daterangepicker_start]').val(dates[0].format(this.format));
-                this.container.find('input[name=daterangepicker_end]').val(dates[1].format(this.format));
+                if (typeof dates[0] === 'function') {
+                    this.container.find('input[name=daterangepicker_start]').val(dates[0]().format(this.format));
+                } else {
+                    this.container.find('input[name=daterangepicker_start]').val(dates[0].format(this.format));
+                }
+
+                if (typeof dates[1] === 'function') {
+                    this.container.find('input[name=daterangepicker_start]').val(dates[1]().format(this.format));
+                } else {
+                    this.container.find('input[name=daterangepicker_start]').val(dates[1].format(this.format));
+                }
             }
         },
 
@@ -574,8 +588,17 @@
             } else {
                 var dates = this.ranges[label];
 
-                this.startDate = dates[0];
-                this.endDate = dates[1];
+                if(typeof dates[0] === 'function') {
+                    this.startDate = dates[0]();
+                } else {
+                    this.startDate = dates[0];
+                }
+
+                if(typeof dates[1] === 'function') {
+                    this.endDate = dates[1]();
+                } else {
+                    this.endDate = dates[1];
+                }
 
                 if (!this.timePicker) {
                     this.startDate.startOf('day');


### PR DESCRIPTION
I needed range picker options like 'Last Hour' and 'Last 4 Hours' that would be accurate even if the user had their browser open for 15 minutes. With the original static values provided for ranges if the user left the window open for 15 minutes then came back 'Last 4 Hours' would actually be the 'Last 4 Hours' - 15 so users had to refresh their browser to get what they really wanted. By adding functions for the start and end of the range I am able to recalculate the start and end each time the range is clicked.
