### PR TITLE
Update moment.js dependency, use the correct name.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
   ],
   "dependencies": {
     "jquery": ">=1.10",
-    "momentjs": "~2.5.1"
-  }
+    "moment": "~2.7.0"
+ } 
 }


### PR DESCRIPTION
Official bower name for `moment.js` is `moment` as mentioned on the [website](http://momentjs.com/).

Related to #357.
