### PR TITLE
Improve border-radius for better visual of selected range.

### DIFF
--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -224,6 +224,24 @@
   border-radius: 0;
 }
 
+.daterangepicker td.available + td.start-date {
+  -webkit-border-radius: 4px 0 0 4px;
+  -moz-border-radius: 4px 0 0 4px;
+  border-radius: 4px 0 0 4px;
+}
+
+.daterangepicker td.in-range + td.end-date{
+  -webkit-border-radius: 0 4px 4px 0;
+  -moz-border-radius: 0 4px 4px 0;
+  border-radius: 0 4px 4px 0;
+}
+
+.daterangepicker td.start-date.end-date{
+  -webkit-border-radius: 4px !important;
+  -moz-border-radius: 4px !important;
+  border-radius: 4px !important;
+}
+
 .daterangepicker td.active, .daterangepicker td.active:hover {
   background-color: #357ebd;
   border-color: #3071a9;


### PR DESCRIPTION
This pull request make better use of border radius to (IMO) help the visual flow between the two calendars and makes the start/end date more clear. Creating more of a bookend feel.
## Before

![screen shot 2014-07-09 at 10 28 57 am](https://cloud.githubusercontent.com/assets/945202/3526740/834ac3c6-077e-11e4-8814-f2ed43a8792d.png)
## After

![screen shot 2014-07-09 at 10 28 08 am](https://cloud.githubusercontent.com/assets/945202/3526743/8ee74164-077e-11e4-85ef-06f48653afb2.png)
