### PR TITLE
Add jQuery require to CommonJS module definition

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -15,7 +15,15 @@
 
   } else if (typeof exports !== 'undefined') {
     var momentjs = require('moment');
-    factory(root, exports, momentjs);
+    var jQuery;
+    try {
+      jQuery = require('jquery');
+    } catch (err) {
+      jQuery = window.jQuery;
+      if (!jQuery) throw new Error('jQuery dependency not found');
+    }
+
+    factory(root, exports, momentjs, jQuery);
 
   // Finally, as a browser global.
   } else {


### PR DESCRIPTION
Currently the CommonJS (node, browserify) side of the module definition doesn't work due to the fact that it doesn't pass jQuery in to the factory function. This PR rectifies that, and accounts for the two most common cases:
- where jQuery is already included on the page
- where the npm 'jquery' package is bundled by browserify
