### PR TITLE
Calendars are displayed correctly after "switching" singleDatePicker on/off when datepicker is already initialized.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -364,7 +364,7 @@
                 if (!this.container.find('.calendar.right').hasClass('single'))
                     this.container.find('.calendar.right').addClass('single');
             } else {
-                this.container.find('.calendar.right').removeClass('single');
+                this.container.find('.calendar.right').show().removeClass('single');
                 this.container.find('.calendar.left').show();
                 this.container.find('.ranges').show();
             }


### PR DESCRIPTION
Here is the situation:

I have two option sets - **A** and **B**. 
**A** has option `singleDatePicker: true`, 
**B** - `singleDatePicker: false`.

At first, datepicker is initialized with options **B** and everything is as expected - can select range, there are two calendars, etc.
Switching to **A** _converts_ datepicker to single picker as expected - one calendar.
Switching back to **B**, picker is _converted_ to range selector as expected but only with one calendar.

Looks like `.left` calendar is hidden after switching to single mode and never shown again (when switching back to range mode)
Also, when picker is shown on right, calendars are swapped and `.single` is messed up as well as wrong calendar is hidden/shown.
