### PR TITLE
Add support for moment 2.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-daterangepicker",
   "version": "1.3.9",
   "main": [
-    "daterangepicker.js", 
+    "daterangepicker.js",
     "daterangepicker-bs3.css"
   ],
   "ignore": [
@@ -16,6 +16,6 @@
   ],
   "dependencies": {
     "jquery": ">=1.10",
-    "moment": "~2.7.0"
- } 
+    "moment": "~2.8.0"
+ }
 }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -159,9 +159,9 @@
                 toLabel: 'To',
                 weekLabel: 'W',
                 customRangeLabel: 'Custom Range',
-                daysOfWeek: moment()._lang._weekdaysMin.slice(),
-                monthNames: moment()._lang._monthsShort.slice(),
-                firstDay: moment()._lang._week.dow
+                daysOfWeek: moment.weekdaysMin(),
+                monthNames: moment.monthsShort(),
+                firstDay: moment.localeData()._week.dow
             };
 
             this.cb = function () { };


### PR DESCRIPTION
In version 2.8 they renamed all instances of `lang` to `locale`.
Since daterangepicker depends on moment internal API for initial
locale settings, it stopped working.

With this fix I tried to minimize usage of moment internal APIs.
