### PR TITLE
fixing typo so code works as a commonjs module

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -31,7 +31,7 @@
     root.daterangepicker = factory(root, {}, root.momentjs, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
-}(this, function(root, daterangepicker, momentjs, $) {
+}(this, function(root, daterangepicker, moment, $) {
 
     var DateRangePicker = function (element, options, cb) {
 


### PR DESCRIPTION
I made a "react" wrapper around this library, but had to make a few changes for it to work within node (hope you don't mind- https://github.com/skratchdot/react-bootstrap-daterangepicker).  This is one of the changes I had to make.
