### PR TITLE
fixing typo so code works as a commonjs module

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -28,10 +28,10 @@
 
   // Finally, as a browser global.
   } else {
-    root.daterangepicker = factory(root, {}, root.momentjs, (root.jQuery || root.Zepto || root.ender || root.$));
+    root.daterangepicker = factory(root, {}, root.moment, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
-}(this, function(root, daterangepicker, momentjs, $) {
+}(this, function(root, daterangepicker, moment, $) {
 
     var DateRangePicker = function (element, options, cb) {
 


### PR DESCRIPTION
I understand if you don't want to pull this in (after my last disaster)- but I actually tested this time.  The factory function declaration is declaring a 'momentjs' variable that is never actually used inside the function.  By changing to 'moment' I'm able to use this within node.

The mistake with my last pull request is that I didn't test in the browser, and missed line 31 https://github.com/dangrossman/bootstrap-daterangepicker/blob/master/daterangepicker.js#L31 which calls the factory function.  It passes in an undefined 'momentjs'.  By changing this variable to 'moment', we pass in the global instance to the factory function.

The downside is that 'moment.js' _must_ be loaded before daterangepicker.js is loaded. I'm not sure if you want to make this concession or not (although I think that is the case with the current codebase).

Also, feel free to just close this out.  I don't want to break live sites (or the codebase in general)- I just thought it looked like a bug that should be fixed (but I might be missing something).

I pushed this change to a gh-pages branch as well so you can check it out live: http://skratchdot.github.io/bootstrap-daterangepicker/examples.html

Thanks for your work on this lib.
