### PR TITLE
Bug Fix: Incorrect date format when manually entering the date.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -627,7 +627,7 @@
         // when a date is typed into the start to end date textboxes
         inputsChanged: function (e) {
             var el = $(e.target);
-            var date = moment(el.val());
+            var date = moment(el.val(), this.format);
             if (!date.isValid()) return;
 
             var startDate, endDate;


### PR DESCRIPTION
In the current version if you use a date format like 'DD/MM/YYYY', when you manually enter the date into the start or end date of the daterange picker, the month and day is swapped because of incorrect format.
