### PR TITLE
Use the change event instead of the keyup event.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -113,7 +113,7 @@
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.updateFromControl, this)
+                'change.daterangepicker': $.proxy(this.updateFromControl, this)
             });
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));


### PR DESCRIPTION
It should be unnoticeable for end users, but this makes automation such as acceptance tests much easier.
