### PR TITLE
Added dateLimitMin option to restrict minimum date range.  #424

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -686,9 +686,9 @@
         clickPrev: function (e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
-                this.leftCalendar.month.subtract('month', 1);
+                this.leftCalendar.month.subtract(1, 'month');
             } else {
-                this.rightCalendar.month.subtract('month', 1);
+                this.rightCalendar.month.subtract(1, 'month');
             }
             this.updateCalendars();
         },
@@ -696,9 +696,9 @@
         clickNext: function (e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
-                this.leftCalendar.month.add('month', 1);
+                this.leftCalendar.month.add(1, 'month');
             } else {
-                this.rightCalendar.month.add('month', 1);
+                this.rightCalendar.month.add(1, 'month');
             }
             this.updateCalendars();
         },
@@ -720,7 +720,7 @@
             this.chosenLabel = this.locale.customRangeLabel;
             if (startDate.isAfter(endDate)) {
                 var difference = this.endDate.diff(this.startDate);
-                endDate = moment(startDate).add('ms', difference);
+                endDate = moment(startDate).add(difference, 'ms');
             }
             this.startDate = startDate;
             this.endDate = endDate;
@@ -873,8 +873,8 @@
             var daysInMonth = moment([year, month]).daysInMonth();
             var firstDay = moment([year, month, 1]);
             var lastDay = moment([year, month, daysInMonth]);
-            var lastMonth = moment(firstDay).subtract('month', 1).month();
-            var lastYear = moment(firstDay).subtract('month', 1).year();
+            var lastMonth = moment(firstDay).subtract(1, 'month').month();
+            var lastYear = moment(firstDay).subtract(1, 'month').year();
 
             var daysInLastMonth = moment([lastYear, lastMonth]).daysInMonth();
 
@@ -901,7 +901,7 @@
 
             var curDate = moment([lastYear, lastMonth, startDay, 12, minute]);
             var col, row;
-            for (i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add('hour', 24)) {
+            for (i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add(24, 'hour')) {
                 if (i > 0 && col % 7 === 0) {
                     col = 0;
                     row++;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -132,6 +132,7 @@
             this.minDate = false;
             this.maxDate = false;
             this.dateLimit = false;
+            this.dateLimitMin = false;
 
             this.showDropdowns = false;
             this.showWeekNumbers = false;
@@ -204,6 +205,9 @@
 
             if (typeof options.dateLimit === 'object')
                 this.dateLimit = options.dateLimit;
+
+            if (typeof options.dateLimitMin === 'object')
+                this.dateLimitMin = options.dateLimitMin;
 
             if (typeof options.locale === 'object') {
 
@@ -745,6 +749,12 @@
                         endDate = maxDate;
                     }
                 }
+                if (typeof this.dateLimitMin === 'object') {
+                    var minDate = moment(startDate).add(this.dateLimitMin).startOf('day');
+                    if (endDate.isBefore(minDate)) {
+                        endDate = minDate;
+                    }
+                }
             } else {
                 startDate = this.startDate;
                 endDate = this.rightCalendar.calendar[row][col];
@@ -754,6 +764,12 @@
                         startDate = minDate;
                     }
                 }
+                if (typeof this.dateLimitMin === 'object') {
+                    var maxDate = moment(endDate).subtract(this.dateLimitMin).startOf('day');
+                    if (startDate.isAfter(maxDate)) {
+                        startDate = maxDate;
+                    }
+                }                
             }
 
             if (this.singleDatePicker && cal.hasClass('left')) {

--- a/examples.html
+++ b/examples.html
@@ -127,7 +127,7 @@
                   }
 
                   var optionSet1 = {
-                    startDate: moment().subtract('days', 29),
+                    startDate: moment().subtract(29, 'days'),
                     endDate: moment(),
                     minDate: '01/01/2012',
                     maxDate: '12/31/2014',
@@ -139,11 +139,11 @@
                     timePicker12Hour: true,
                     ranges: {
                        'Today': [moment(), moment()],
-                       'Yesterday': [moment().subtract('days', 1), moment().subtract('days', 1)],
-                       'Last 7 Days': [moment().subtract('days', 6), moment()],
-                       'Last 30 Days': [moment().subtract('days', 29), moment()],
+                       'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                       'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+                       'Last 30 Days': [moment().subtract(29, 'days'), moment()],
                        'This Month': [moment().startOf('month'), moment().endOf('month')],
-                       'Last Month': [moment().subtract('month', 1).startOf('month'), moment().subtract('month', 1).endOf('month')]
+                       'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
                     },
                     opens: 'left',
                     buttonClasses: ['btn btn-default'],
@@ -164,20 +164,20 @@
                   };
 
                   var optionSet2 = {
-                    startDate: moment().subtract('days', 7),
+                    startDate: moment().subtract(7, 'days'),
                     endDate: moment(),
                     opens: 'left',
                     ranges: {
                        'Today': [moment(), moment()],
-                       'Yesterday': [moment().subtract('days', 1), moment().subtract('days', 1)],
-                       'Last 7 Days': [moment().subtract('days', 6), moment()],
-                       'Last 30 Days': [moment().subtract('days', 29), moment()],
+                       'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                       'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+                       'Last 30 Days': [moment().subtract(29, 'days'), moment()],
                        'This Month': [moment().startOf('month'), moment().endOf('month')],
-                       'Last Month': [moment().subtract('month', 1).startOf('month'), moment().subtract('month', 1).endOf('month')]
+                       'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
                     }
                   };
 
-                  $('#reportrange span').html(moment().subtract('days', 29).format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
+                  $('#reportrange span').html(moment().subtract(29, 'days').format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
 
                   $('#reportrange').daterangepicker(optionSet1, cb);
 
@@ -228,7 +228,7 @@
 
                <script type="text/javascript">
                $(document).ready(function() {
-                  $('#reportrange2 span').html(moment().subtract('days', 29).format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
+                  $('#reportrange2 span').html(moment().subtract(29, 'days').format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
                   $('#reportrange2').daterangepicker();
                });
                </script>


### PR DESCRIPTION
dateLimitMin: (object) The minumum span between the selected start and end dates. Can have any property you can add to a moment object (i.e. days, months)