### PR TITLE
Always apply border radius to start and end date

### DIFF
--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -219,22 +219,22 @@
   border-radius: 0;
 }
 
-.daterangepicker td.available + td.start-date {
+.daterangepicker td.start-date {
   -webkit-border-radius: 4px 0 0 4px;
   -moz-border-radius: 4px 0 0 4px;
   border-radius: 4px 0 0 4px;
 }
 
-.daterangepicker td.in-range + td.end-date{
+.daterangepicker td.end-date {
   -webkit-border-radius: 0 4px 4px 0;
   -moz-border-radius: 0 4px 4px 0;
   border-radius: 0 4px 4px 0;
 }
 
-.daterangepicker td.start-date.end-date{
-  -webkit-border-radius: 4px !important;
-  -moz-border-radius: 4px !important;
-  border-radius: 4px !important;
+.daterangepicker td.start-date.end-date {
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
 }
 
 .daterangepicker td.active, .daterangepicker td.active:hover {


### PR DESCRIPTION
The rounded corners on start and end date isn't applied correctly on days at the start of the week.

Before patch:

![before](https://cloud.githubusercontent.com/assets/2064938/4025054/9f970800-2be6-11e4-9aea-d5c62d75e0fa.png)

After patch:

![after](https://cloud.githubusercontent.com/assets/2064938/4025055/aaa9bf4e-2be6-11e4-95f4-87b6c2d388b5.png)
