### PR TITLE
Added dateSelected event

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Several events are triggered on the element you attach the picker to, which you 
 
 `cancel.daterangepicker`: Triggered when the cancel button is clicked
 
+`dateSelected.daterangepicker`: Triggered when a date is clicked
+
 Some applications need a "clear" instead of a "cancel" functionality, which can be achieved by changing the button label and watching for the cancel event:
 
 ````

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -773,6 +773,8 @@
 
             if (this.singleDatePicker)
                 this.clickApply();
+
+            this.element.trigger('dateSelected.daterangepicker', this);
         },
 
         clickApply: function (e) {


### PR DESCRIPTION
Adds an event so developers can be notified when a user has selected a date. I'm using this to show only one calendar at a time for a responsive design.
