### PR TITLE
Also single date

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -897,12 +897,9 @@
                     i++;
                 }
             }
-            if (customRange && !specificDate) {
-                this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
-                this.showCalendars();
-            } else if (specificDate) {
+            if (customRange || specificDate) {
                 this.container.find('.ranges li:contains("' + this.chosenLabel + '")').addClass('active');
-                this.showCalendars();                
+                this.showCalendars();
             }
         },
 


### PR DESCRIPTION
It displays a single calendar so the user can pick just one date
In order to work it needs a config option: `this.withSingleDate: true`
That option enables a new item just above the 'Custom Range' named 'Specific Date'
This new item can be named anyway through the `locale: {}` config options object.
In order to minimize the refactoring, is the best solution that I can come with, right now.
I am just happy to know is on the right path, and make me the comments you see are in need; if you want to incorporate this in your project.
Thanks for this awesome DatePicker !!!
