### PR TITLE
Add first-call `template` option for HTML template override

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -69,7 +69,7 @@
             options = {};
 
         this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
-        this.container = $(DRPTemplate).appendTo(this.parentEl);
+        this.container = $(options.template || DRPTemplate).appendTo(this.parentEl);
 
         this.setOptions(options, cb);
 


### PR DESCRIPTION
This quick-fix allows following plugin usage:
```js
$('#daterange').daterangeipcker({
  'template': '<div class="daterangepicker dropdown-menu"></div>'
});
```
Container must have `daterangepicker` & `dropdown-menu` classes.

This solution also requires to include following template elements:

`div.calendar.left` & `div.calendar.right` — calendar areas
`div.ranges > .range_inputs` and `.daterangepicker_start_input`, `.daterangepicker_end_input` divs inside
Inside of them — `input[name=daterangepicker_start]` & `input[name=daterangepicker_end]`
`button.applyBtn` and `button.cancelBtn` inside of `.ranges`

Successfully Tested on Chrome with following template:

```html
<div class="daterangepicker dropdown-menu">
	<div class="calendars-grid">
		<div class="row daterangepicker-row-inputs">
			<div class="col-md-6">
				<div class="daterangepicker_start_input input-group">
					<span class="input-group-addon">От</span>
					<input class="form-control" type="text" name="daterangepicker_start" value="">
				</div>
			</div>
			<div class="col-md-6">
				<div class="daterangepicker_end_input input-group">
					<span class="input-group-addon">до</span>
					<input class="form-control" type="text" name="daterangepicker_end" value="">
				</div>
			</div>
		</div>
		<div class="calendar left">
			<div class="calendar-date"></div>
		</div>
		<div class="calendar right">
			<div class="calendar-date"></div>
		</div>
	</div>
	<div class="ranges">
		<div class="range_inputs">
			<button class="applyBtn btn btn-sm btn-success">Показать</button>
			&nbsp;
			<button class="cancelBtn btn btn-sm btn-default">Отмена</button>
		</div>
	</div>
</div>
```