### PR TITLE
fixing issue where end date before start date of range

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -848,12 +848,18 @@
                 start.minute(minute);
                 this.startDate = start;
                 this.leftCalendar.month.hour(hour).minute(minute);
+                if(this.singleDatePicker) {
+                    this.endDate = start.clone();
+                }
             } else {
                 var end = this.endDate.clone();
                 end.hour(hour);
                 end.minute(minute);
                 this.endDate = end;
                 this.rightCalendar.month.hour(hour).minute(minute);
+                if ( this.singleDatePicker) {
+                    this.startDate = end.clone();
+                }
             }
 
             this.updateCalendars();


### PR DESCRIPTION
With single date picker, if you pick today then go back to another day, then change the hour few times.
you will notice the apply button gets disabled because the end of the range becomes before the first date.

Tested with minDate set to moment()
