### PR TITLE
fix calendar swap on setOptions

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -46,8 +46,8 @@
 
         //create the picker HTML object
         var DRPTemplate = '<div class="daterangepicker dropdown-menu">' +
-                '<div class="calendar left"></div>' +
-                '<div class="calendar right"></div>' +
+                '<div class="calendar first left"></div>' +
+                '<div class="calendar second right"></div>' +
                 '<div class="ranges">' +
                   '<div class="range_inputs">' +
                     '<div class="daterangepicker_start_input">' +
@@ -393,20 +393,20 @@
 
             if (this.opens == 'right' || this.opens == 'center') {
                 //swap calendar positions
-                var left = this.container.find('.calendar.left');
-                var right = this.container.find('.calendar.right');
+                var first = this.container.find('.calendar.first');
+                var second = this.container.find('.calendar.second');
 
-                if (right.hasClass('single')) {
-                    right.removeClass('single');
-                    left.addClass('single');
+                if (second.hasClass('single')) {
+                    second.removeClass('single');
+                    first.addClass('single');
                 }
 
-                left.removeClass('left').addClass('right');
-                right.removeClass('right').addClass('left');
+                first.removeClass('left').addClass('right');
+                second.removeClass('right').addClass('left');
 
                 if (this.singleDatePicker) {
-                    left.show();
-                    right.hide();
+                    first.show();
+                    second.hide();
                 }
             }
 
@@ -869,7 +869,7 @@
             this.rightCalendar.calendar = this.buildCalendar(this.rightCalendar.month.month(), this.rightCalendar.month.year(), this.rightCalendar.month.hour(), this.rightCalendar.month.minute(), 'right');
             this.container.find('.calendar.left').empty().html(this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.maxDate, 'left'));
             this.container.find('.calendar.right').empty().html(this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.singleDatePicker ? this.minDate : this.startDate, this.maxDate, 'right'));
-            
+
             this.container.find('.ranges li').removeClass('active');
             var customRange = true;
             var i = 0;


### PR DESCRIPTION
When the calendar is in the default open 'right' mode, the left and right calendars swap positions every time `setOptions` is called. This method is used not just in the creation of the datepicker, but whenever the existing datepicker is updated. In my case, I update the datepicker dates every time the datepicker is opened. This causes the starting date to alternate being on the left and right each time it is open. A JSBin of this effect is here, just click on the input more than once to see the effect: http://jsbin.com/yanuliwoco/1/edit?js,output

The simple solution I implemented is to add an additional class to each calendar that doesn't get swapped. The 'left' and 'right' classes can be adjusted based on these classes, making sure that they are put on the correct calendar, no matter how many times it is updated.

Here is the JSBin of the fix in action: http://jsbin.com/vuqoyecohe/2/edit?js,output

Here is a gif of the bug:
![datepicker_calendar_bug](https://cloud.githubusercontent.com/assets/5260472/4837918/32f5d694-5fe0-11e4-8dfc-a26cc7822055.gif)

closes #435 
