### PR TITLE
simplify event listener removal

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -605,9 +605,7 @@
             if (!this.isShowing) return;
 
             $(document)
-              .off('mousedown.daterangepicker')
-              .off('click.daterangepicker', '[data-toggle=dropdown]')
-              .off('focusin.daterangepicker');
+              .off('.daterangepicker');
 
             this.element.removeClass('active');
             this.container.hide();
@@ -869,7 +867,7 @@
             this.rightCalendar.calendar = this.buildCalendar(this.rightCalendar.month.month(), this.rightCalendar.month.year(), this.rightCalendar.month.hour(), this.rightCalendar.month.minute(), 'right');
             this.container.find('.calendar.left').empty().html(this.renderCalendar(this.leftCalendar.calendar, this.startDate, this.minDate, this.maxDate, 'left'));
             this.container.find('.calendar.right').empty().html(this.renderCalendar(this.rightCalendar.calendar, this.endDate, this.singleDatePicker ? this.minDate : this.startDate, this.maxDate, 'right'));
-            
+
             this.container.find('.ranges li').removeClass('active');
             var customRange = true;
             var i = 0;


### PR DESCRIPTION
This is not a big deal, just a little code cleanup. It seems you handled the bug from the $.proxy functions (which can't be used for event removal) [here](https://github.com/dangrossman/bootstrap-daterangepicker/commit/e3d1d06c355a3cc493c7498e6345d232ac7aa55c). You don't have any other event listeners on the document, so you can just use the namespace to remove them.
