### PR TITLE
add seconds option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ $('input[name="daterange"]').daterangepicker(
 
 `timePicker12Hour`: (boolean) Use 12-hour instead of 24-hour times, adding an AM/PM select box
 
+`timePickerSeconds`: (boolean) Show seconds in the timePicker
+
 `ranges`: (object) Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds of the range
 
 `opens`: (string: 'left'/'right'/'center') Whether the picker appears aligned to the left, to the right, or centered under the HTML element it's attached to

--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -269,7 +269,7 @@
   width: 40%;
 }
 
-.daterangepicker select.hourselect, .daterangepicker select.minuteselect, .daterangepicker select.ampmselect {
+.daterangepicker select.hourselect, .daterangepicker select.minuteselect, .daterangepicker select.secondselect, .daterangepicker select.ampmselect {
   width: 60px;
   margin-bottom: 0;
 }

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -301,7 +301,7 @@
   width: 40%;
 }
 
-.daterangepicker select.hourselect, .daterangepicker select.minuteselect, .daterangepicker select.ampmselect {
+.daterangepicker select.hourselect, .daterangepicker select.minuteselect, .daterangepicker select.secondselect, .daterangepicker select.ampmselect {
   width: 50px;
   margin-bottom: 0;
 }


### PR DESCRIPTION
Adds an optional seconds dropdown in the timePicker. It would only be shown if the timePickerSeconds option is true. This was a hard requirement for me, figured I would push it up if you want to use it. Here is a JSBin before the change: http://jsbin.com/jowahawaxo/2/edit

Here is a JSBin with the new code and seconds enabled: http://jsbin.com/qiyehutana/3/edit

Here is what it looks like:
![with_seconds](https://cloud.githubusercontent.com/assets/5260472/4839006/06eba418-5ff7-11e4-949e-bcb3283f05c1.png)

And the result:
![with_seconds_result](https://cloud.githubusercontent.com/assets/5260472/4839007/0a8b05c8-5ff7-11e4-9dd8-0640198c46a4.png)

relates to #184 and #301 
