### PR TITLE
enforce min and max date in custom date range if it exists

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -753,6 +753,13 @@
                 var difference = this.endDate.diff(this.startDate);
                 endDate = moment(startDate).add(difference, 'ms');
             }
+            if (this.minDate && startDate.isBefore(this.minDate)){
+                startDate = this.minDate;
+            }
+            if (this.maxDate && endDate.isAfter(this.maxDate)){
+                endDate = this.maxDate;
+            }
+
             this.startDate = startDate;
             this.endDate = endDate;
 


### PR DESCRIPTION
Used this for a project and noticed that the custom range let's you go outside of the bounds of min and max date.  Not sure what else may need to be updated, but this will change the start / end inputs to the min / max if you enter a value outside of those params.
