### PR TITLE
Added option 'stayInView' for displaying upside when there's not enough space vertically.

### DIFF
--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -13,13 +13,16 @@
   z-index: 3000;
 }
 
-.daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar {
+.daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar,
+.daterangepicker.openstopleft .ranges, .daterangepicker.openstopleft .calendar{
   float: left;
   margin: 4px;
 }
 
 .daterangepicker.opensright .ranges, .daterangepicker.opensright .calendar,
-.daterangepicker.openscenter .ranges, .daterangepicker.openscenter .calendar {
+.daterangepicker.openscenter .ranges, .daterangepicker.openscenter .calendar,
+.daterangepicker.openstopright .ranges, .daterangepicker.openstopright .calendar,
+.daterangepicker.openstopcenter .ranges, .daterangepicker.openstopcenter .calendar {
   float: right;
   margin: 4px;
 }
@@ -218,6 +221,83 @@
   border-bottom: 6px solid #fff;
   border-left: 6px solid transparent;
   content: '';
+}
+
+.daterangepicker.openstopleft:before {
+    position: absolute;
+    bottom: -7px;
+    right: 9px;
+    display: inline-block;
+    border-right: 7px solid transparent;
+    border-top: 7px solid #ccc;
+    border-left: 7px solid transparent;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
+    content: '';
+}
+
+.daterangepicker.openstopleft:after {
+    position: absolute;
+    bottom: -6px;
+    right: 10px;
+    display: inline-block;
+    border-right: 6px solid transparent;
+    border-top: 6px solid #fff;
+    border-left: 6px solid transparent;
+    content: '';
+}
+
+.daterangepicker.openstopcenter:before {
+    position: absolute;
+    top: -7px;
+    bottom: 0;
+    right: 0;
+    width: 0;
+    margin-left: auto;
+    margin-right: auto;
+    display: inline-block;
+    border-right: 7px solid transparent;
+    border-top: 7px solid #ccc;
+    border-left: 7px solid transparent;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
+    content: '';
+}
+
+.daterangepicker.openstopcenter:after {
+    position: absolute;
+    bottom: -6px;
+    left: 0;
+    right: 0;
+    width: 0;
+    margin-left: auto;
+    margin-right: auto;
+    display: inline-block;
+    border-right: 6px solid transparent;
+    border-top: 6px solid #fff;
+    border-left: 6px solid transparent;
+    content: '';
+}
+
+.daterangepicker.openstopright:before {
+    position: absolute;
+    bottom: -7px;
+    left: 9px;
+    display: inline-block;
+    border-right: 7px solid transparent;
+    border-top: 7px solid #ccc;
+    border-left: 7px solid transparent;
+    border-bottom-color: rgba(0, 0, 0, 0.2);
+    content: '';
+}
+
+.daterangepicker.openstopright:after {
+    position: absolute;
+    bottom: -6px;
+    left: 10px;
+    display: inline-block;
+    border-right: 6px solid transparent;
+    border-top: 6px solid #fff;
+    border-left: 6px solid transparent;
+    content: '';
 }
 
 .daterangepicker table {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -140,6 +140,7 @@
             this.timePicker12Hour = true;
             this.singleDatePicker = false;
             this.ranges = {};
+            this.stayInView = false;
 
             this.opens = 'right';
             if (this.element.hasClass('pull-right'))
@@ -358,6 +359,10 @@
                 this.container.find('.ranges ul').remove();
                 this.container.find('.ranges').prepend(list);
             }
+            
+            if (typeof options.stayInView === 'boolean'){
+              this.stayInView = options.stayInView;
+            }
 
             if (typeof callback === 'function') {
                 this.cb = callback;
@@ -525,7 +530,7 @@
             var topOffset = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
             var elemBottom = topOffset + this.container.outerHeight();
             // if container height passes the bottom of the view, show it on top
-            if ((elemBottom >= docViewBottom)) {
+            if ((elemBottom >= docViewBottom) && this.stayInView == true) {
                 showOnTop = true;
             }
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -520,6 +520,15 @@
 
         move: function () {
             var parentOffset = { top: 0, left: 0 };
+            var showOnTop = false;
+            var docViewBottom = $(window).scrollTop() + $(window).height();
+            var topOffset = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
+            var elemBottom = topOffset + this.container.outerHeight();
+            // if container height passes the bottom of the view, show it on top
+            if ((elemBottom >= docViewBottom)) {
+                showOnTop = true;
+            }
+
             var parentRightEdge = $(window).width();
             if (!this.parentEl.is('body')) {
                 parentOffset = {
@@ -528,10 +537,15 @@
                 };
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
             }
+            
+            if (showOnTop) {
+                // calculate new top offset
+                topOffset = this.element.offset().top - this.container.outerHeight() - parentOffset.top - 2;
+            }
 
             if (this.opens == 'left') {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
+                    top: topOffset,
                     right: parentRightEdge - this.element.offset().left - this.element.outerWidth(),
                     left: 'auto'
                 });
@@ -543,7 +557,7 @@
                 }
             } else if (this.opens == 'center') {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
+                    top: topOffset,
                     left: this.element.offset().left - parentOffset.left + this.element.outerWidth() / 2
                             - this.container.outerWidth() / 2,
                     right: 'auto'
@@ -556,7 +570,7 @@
                 }
             } else {
                 this.container.css({
-                    top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
+                    top: topOffset,
                     left: this.element.offset().left - parentOffset.left,
                     right: 'auto'
                 });
@@ -566,6 +580,27 @@
                         right: 0
                     });
                 }
+            }
+            
+            // switch between top and bottom classes
+            if (showOnTop) {
+                if (this.container.hasClass("opensleft"))
+                    this.container.removeClass("opensleft").addClass("openstopleft");
+
+                if (this.container.hasClass("openscenter"))
+                    this.container.removeClass("openscenter").addClass("openstopcenter");
+
+                if (this.container.hasClass("opensright"))
+                    this.container.removeClass("opensright").addClass("openstopright");
+            } else {
+                if (this.container.hasClass("openstopleft"))
+                    this.container.removeClass("openstopleft").addClass("opensleft");
+
+                if (this.container.hasClass("openstopcenter"))
+                    this.container.removeClass("openstopcenter").addClass("openscenter");
+
+                if (this.container.hasClass("openstopright"))
+                    this.container.removeClass("openstopright").addClass("opensright");
             }
         },
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -608,6 +608,7 @@
             if (this.element.hasClass('active')) {
                 this.hide();
             } else {
+                this.move();
                 this.show();
             }
         },
@@ -616,6 +617,7 @@
             if (this.isShowing) return;
 
             this.element.addClass('active');
+            this.move();
             this.container.show();
             this.move();
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -285,7 +285,7 @@
             }
 
             // update day names order to firstDay
-            if (this.locale.firstDay != 0) {
+            if (this.locale.firstDay !== 0) {
                 var iterator = this.locale.firstDay;
                 while (iterator > 0) {
                     this.locale.daysOfWeek.push(this.locale.daysOfWeek.shift());


### PR DESCRIPTION
The users can have the daterangepicker popup to show upside of the input by setting the `stayInView` parameter true. When set to false, it'll always show downside of the input.