### PR TITLE
hideCalendarsOnRange option added; updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ $('input[name="daterange"]').daterangepicker(
 
 `timePickerSeconds`: (boolean) Show seconds in the timePicker
 
+`hideCalendarsOnRange`: (boolean) Hide calendars if ranges (e.g. yesterday, last month, etc) are chosen (defaults to true)
+
 `ranges`: (object) Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds of the range
 
 `opens`: (string: 'left'/'right'/'center') Whether the picker appears aligned to the left, to the right, or centered under the HTML element it's attached to

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -134,6 +134,7 @@
             this.maxDate = false;
             this.dateLimit = false;
 
+            this.hideCalendarsOnRange = true;
             this.showDropdowns = false;
             this.showWeekNumbers = false;
             this.timePicker = false;
@@ -266,6 +267,10 @@
             if (typeof options.showDropdowns === 'boolean') {
                 this.showDropdowns = options.showDropdowns;
             }
+
+            if (typeof options.hideCalendarsOnRange === 'boolean') {
+                this.hideCalendarsOnRange = options.hideCalendarsOnRange;
+            }            
 
             if (typeof options.singleDatePicker === 'boolean') {
                 this.singleDatePicker = options.singleDatePicker;
@@ -724,8 +729,10 @@
                 this.updateCalendars();
 
                 this.updateInputText();
-
-                this.hideCalendars();
+		
+                if(this.hideCalendarsOnRange)
+                    this.hideCalendars();
+                
                 this.hide();
                 this.element.trigger('apply.daterangepicker', this);
             }
@@ -923,10 +930,10 @@
                 }
                 i++;
             }
-            if (customRange) {
-                this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
+            if (!this.hideCalendarsOnRange || customRange)
                 this.showCalendars();
-            }
+            if(customRange)
+                this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
         },
 
         buildCalendar: function (month, year, hour, minute, second, side) {


### PR DESCRIPTION
My client found it confusing that the calendars did not appear when a "preset" range (e.g. yesterday, last 30 days, etc) was chosen.  He wanted it to work a bit more like Google Analytics' date range selector, which leaves the calendar open even when a preset is used.  To accomplish this I added the "hideCalendarsOnRange" option.  It defaults to TRUE, leaving your default behavior, but if you set it to FALSE the calendars will remain in view.