### PR TITLE
Fixed wrong order of date pickers on mobile

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -424,10 +424,10 @@
                     second.removeClass('single');
                     first.addClass('single');
                 }
-
-                first.removeClass('left').addClass('right');
-                second.removeClass('right').addClass('left');
-
+                if($(document).width() > 840){ // how to set this width better?
+                    first.removeClass('left').addClass('right');
+                    second.removeClass('right').addClass('left');
+                }
                 if (this.singleDatePicker) {
                     first.show();
                     second.hide();


### PR DESCRIPTION
When the screen gets over 840px wide, the date pickers reorder but the order is wrong(it should be the other way around). What I did looks like a workaround but I couldn't figure out how not to hack it.