### PR TITLE
Allow setting options with HTML5 data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ $('input[name="daterange"]').daterangepicker(
 );
 ````
 
+Options may also be set using HTML5 data attributes. For example, timePicker="true" would be set with:
+
+```
+<input type="text" data-time-picker="true" name="daterange">
+```
+
 ## Options
 
 `startDate`: (Date object, moment object or string) The start of the initially selected date range

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -71,6 +71,10 @@
         this.parentEl = (typeof options === 'object' && options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(DRPTemplate).appendTo(this.parentEl);
 
+        //allow setting options with data attributes
+        //data-api options will be overwritten with custom javascript options
+        options = $.extend(this.element.data(), options);
+        
         this.setOptions(options, cb);
 
         //apply CSS classes and labels to buttons


### PR DESCRIPTION
Sometimes it's necessary to set options without modifying the javascript. This pull request adds the flexibility to allow setting options through HTML5 data attributes.

This also eases the transition for people coming from bootstrap datetimepicker who already have existing code which uses data attributes: http://eonasdan.github.io/bootstrap-datetimepicker/#example5

This addresses issue #195