### PR TITLE
Remove invalid date in JSDoc

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,7 +1,6 @@
 /**
 * @version: 1.3.17
 * @author: Dan Grossman http://www.dangrossman.info/
-* @date: 2014-11-25
 * @copyright: Copyright (c) 2012-2014 Dan Grossman. All rights reserved.
 * @license: Licensed under the MIT license. See http://www.opensource.org/licenses/mit-license.php
 * @website: http://www.improvely.com/


### PR DESCRIPTION
date is not a valid JSDoc block tag, thus it issues warning while minifying (tested with Google closure)
i propose to remove it.