### PR TITLE
Move apply/cancel buttons out of the ranges div

### DIFF
--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -12,6 +12,10 @@
   z-index: 3000;
 }
 
+.daterangepicker .buttons {
+	margin: 4px;
+}
+
 .daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar {
   float: left;
   margin: 4px;
@@ -23,7 +27,7 @@
   margin: 4px;
 }
 
-.daterangepicker .ranges {
+.daterangepicker .ranges, .daterangepicker .buttons {
   width: 160px;
   text-align: left;
 }

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -7,9 +7,13 @@
  * Built for http://www.improvely.com
  */
 
- .daterangepicker.dropdown-menu {
+.daterangepicker.dropdown-menu {
   max-width: none;
   z-index: 3000;
+}
+
+.daterangepicker .buttons {
+	margin: 4px;
 }
 
 .daterangepicker.opensleft .ranges, .daterangepicker.opensleft .calendar {
@@ -23,11 +27,11 @@
   margin: 4px;
 }
 
-.daterangepicker.single .ranges, .daterangepicker.single .calendar {
+.daterangepicker.single .ranges, .daterangepicker.single .calendar, .daterangepicker.single .buttons {
   float: none;
 }
 
-.daterangepicker .ranges {
+.daterangepicker .ranges, .daterangepicker .buttons {
   width: 160px;
   text-align: left;
 }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -58,9 +58,11 @@
                       '<label for="daterangepicker_end"></label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_end" value="" />' +
                     '</div>' +
-                    '<button class="applyBtn" disabled="disabled"></button>&nbsp;' +
-                    '<button class="cancelBtn"></button>' +
                   '</div>' +
+                '</div>' +
+                '<div class="buttons">' +
+                  '<button class="applyBtn" disabled="disabled"></button>&nbsp;' +
+                  '<button class="cancelBtn"></button>' +
                 '</div>' +
               '</div>';
 
@@ -100,14 +102,16 @@
             .on('change.daterangepicker', 'select.hourselect,select.minuteselect,select.secondselect,select.ampmselect', $.proxy(this.updateTime, this));
 
         this.container.find('.ranges')
-            .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
-            .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this))
             .on('click.daterangepicker', '.daterangepicker_start_input,.daterangepicker_end_input', $.proxy(this.showCalendars, this))
             .on('change.daterangepicker', '.daterangepicker_start_input,.daterangepicker_end_input', $.proxy(this.inputsChanged, this))
             .on('keydown.daterangepicker', '.daterangepicker_start_input,.daterangepicker_end_input', $.proxy(this.inputsKeydown, this))
             .on('click.daterangepicker', 'li', $.proxy(this.clickRange, this))
             .on('mouseenter.daterangepicker', 'li', $.proxy(this.enterRange, this))
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
+
+        this.container.find('.buttons')
+            .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
+            .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this))
 
         if (this.element.is('input')) {
             this.element.on({


### PR DESCRIPTION
This PR moves the apply/cancel buttons out of the ranges div so that they can still be used when ranges are hidden (e.g. when singleDatePicker = true).