### PR TITLE
Fix end date bigger than max date

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -769,7 +769,7 @@
             if (startDate.isAfter(endDate)) {
                 var difference = this.endDate.diff(this.startDate);
                 endDate = moment(startDate).add(difference, 'ms');
-                if (endDate.isAfter(this.maxDate)) {
+                if (this.maxDate && endDate.isAfter(this.maxDate)) {
                   endDate = this.maxDate;
                 }
             }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -769,6 +769,9 @@
             if (startDate.isAfter(endDate)) {
                 var difference = this.endDate.diff(this.startDate);
                 endDate = moment(startDate).add(difference, 'ms');
+                if (endDate.isAfter(this.maxDate)) {
+                  endDate = this.maxDate;
+                }
             }
             this.startDate = startDate;
             this.endDate = endDate;


### PR DESCRIPTION
Added a validation for the end date when selecting a custom start date,
which added to the actual difference could end up being bigger than the
max date configuratoion.