### PR TITLE
Fix year dropdown issues

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -851,6 +851,28 @@
             var month = parseInt(cal.find('.monthselect').val(), 10);
             var year = cal.find('.yearselect').val();
 
+            if (!isLeft) {
+                if (year < this.startDate.year() || (year == this.startDate.year() && month < this.startDate.month())) {
+                    month = this.startDate.month();
+                    year = this.startDate.year();
+                }
+            }
+
+            if (this.minDate) {
+                if (year < this.minDate.year() || (year == this.minDate.year() && month < this.minDate.month())) {
+                    month = this.minDate.month();
+                    year = this.minDate.year();
+                }
+            }
+
+            if (this.maxDate) {
+                if (year > this.maxDate.year() || (year == this.maxDate.year() && month > this.maxDate.month())) {
+                    month = this.maxDate.month();
+                    year = this.maxDate.year();
+                }
+            }
+
+
             this[leftOrRight+'Calendar'].month.month(month).year(year);
             this.updateCalendars();
         },


### PR DESCRIPTION
There are currently three issues with the year dropdown when selecting
a custom range.

To reproduce the errors, use the following fiddle url
http://jsfiddle.net/vitorbarbosa/acozzy2z/ .

1. When changing the left calendar dropdown to year 2014 it does not
respect the assigned minDate. Although it correctly shows the minDate
month in the dropdown (june 2014), it is showing the february month
calendar (log as you will but you quickly can see that the month in the
calendar has 28 days).

2. It does not respect the assigned start date when you select the same
year in the right calendar dropdown. Although it correctly shows the
start date month in the dropdown, it is showing the wrong month
calendar. To reproduce, select 01 August 2014 in the left calendar.
When changing the right calendar to 2014 it will show the correct month
in the dropdown (Aug 2014) but it will show the Feb 2014 month
callendar (28 days again).

3. It does not respect the maxDate month when going changing back the
dropdowns to 2015 (left or right calendar). To reproduce this issue, on
the left calendar change to August 2014 and select day 1. Then on the
same calendar return to year 2015 and although it shows January 2015 in
the calendar dropdowns it is currently showing the calendar for August
2015.

This commit will resolve the aforementioned issues.