### PR TITLE
Added keydown function to hide on tab(9) and enter(13).

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -113,7 +113,8 @@
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.updateFromControl, this)
+                'keyup.daterangepicker': $.proxy(this.updateFromControl, this),
+                'keydown.daterangepicker': $.proxy(this.keydown, this)
             });
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
@@ -526,6 +527,12 @@
                 this.notify();
 
             this.updateCalendars();
+        },
+        
+        keydown: function (e) {
+        	if ((e.keyCode===9)||(e.keyCode===13)) {
+        		this.hide();
+        	}
         },
 
         notify: function () {


### PR DESCRIPTION
This change lets keyboard centric users use the [tab] key to tab out of daterangepicker controls.

This "fixed" this issue [574](https://github.com/dangrossman/bootstrap-daterangepicker/issues/574) for me.