### PR TITLE
Inserting actual minute/second into the list if it isn't already present

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1171,34 +1171,62 @@
                         selected.minute(max_minute);
                 }
 
+                var selectedMinuteDisplayed = false;
+
+                var minutes = [];
+
                 for (i = 0; i < 60; i += this.timePickerIncrement) {
-                    var num = i;
+                    minutes.push(i);
+                }
+
+                if (selected.minute() % this.timePickerIncrement > 0) {
+                    minutes.push(selected.minute());
+                    minutes.sort(function(a, b) {
+                      return a - b;
+                    });
+                }
+
+                minutes.forEach(function(minute) {
+                    var num = minute;
                     if (num < 10)
                         num = '0' + num;
-                    if (i == selected.minute()) {
+                    if (minute == selected.minute()) {
                         html += '<option value="' + i + '" selected="selected">' + num + '</option>';
-                    } else if (i < min_minute || i > max_minute) {
-                        html += '<option value="' + i + '" disabled="disabled" class="disabled">' + num + '</option>';
+                    } else if (minute < min_minute || minute > max_minute) {
+                        html += '<option value="' + minute + '" disabled="disabled" class="disabled">' + num + '</option>';
                     } else {
-                        html += '<option value="' + i + '">' + num + '</option>';
+                        html += '<option value="' + minute + '">' + num + '</option>';
                     }
-                }
+                });
 
                 html += '</select> ';
 
                 if (this.timePickerSeconds) {
                     html += ': <select class="secondselect">';
 
+                    var seconds = [];
+
                     for (i = 0; i < 60; i += this.timePickerIncrement) {
-                        var num = i;
+                        seconds.push(i);
+                    }
+
+                    if (selected.second() % this.timePickerIncrement > 0) {
+                        seconds.push(selected.second());
+                        seconds.sort(function(a, b) {
+                          return a - b;
+                        });
+                    }
+
+                    seconds.forEach(function(second) {
+                        var num = second;
                         if (num < 10)
                             num = '0' + num;
-                        if (i == selected.second()) {
-                            html += '<option value="' + i + '" selected="selected">' + num + '</option>';
+                        if (second == selected.second()) {
+                            html += '<option value="' + second + '" selected="selected">' + num + '</option>';
                         } else {
-                            html += '<option value="' + i + '">' + num + '</option>';
+                            html += '<option value="' + second + '">' + num + '</option>';
                         }
-                    }
+                    });
 
                     html += '</select>';
                 }


### PR DESCRIPTION
For better feedback when making finer-grained selections, in cases where `timePickerIncrement > 1` and the selected time not a round value (e.g. `11:33:03`), this will insert the actual minute and second into the time selection drop-downs.

![screen shot 2015-02-16 at 18 48 40](https://cloud.githubusercontent.com/assets/95854/6216665/75029586-b60c-11e4-845c-222dd4305e7d.png)
