### PR TITLE
validate date inputs and fix same day start/end bug

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -112,7 +112,11 @@
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.updateFromControl, this)
+                'keyup.daterangepicker': (function(event){
+                    if(event.keyCode == 13){
+                        self.updateFromControl()
+                    }
+                })
             });
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
@@ -521,7 +525,7 @@
             this.oldEndDate = this.endDate.clone();
 
             this.startDate = start;
-            this.endDate = end.endOf('day');
+            this.endDate = end;
 
             if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
                 this.notify();
@@ -684,8 +688,8 @@
                 endDate = this.endDate;
             } else {
                 startDate = this.startDate;
-                endDate = (false !== this.maxDate && date.isAfter(this.maxDate)) ? this.maxDate : date.endOf('day');
-            }
+                endDate = (false !== this.maxDate && date.isAfter(this.maxDate)) ? this.maxDate : date;
+           }
             this.setCustomDates(startDate, endDate);
         },
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -521,7 +521,7 @@
             this.oldEndDate = this.endDate.clone();
 
             this.startDate = start;
-            this.endDate = end;
+            this.endDate = end.endOf('day');
 
             if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
                 this.notify();
@@ -684,7 +684,7 @@
                 endDate = this.endDate;
             } else {
                 startDate = this.startDate;
-                endDate = (false !== this.maxDate && date.isAfter(this.maxDate)) ? this.maxDate : date;
+                endDate = (false !== this.maxDate && date.isAfter(this.maxDate)) ? this.maxDate : date.endOf('day');
             }
             this.setCustomDates(startDate, endDate);
         },

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -109,7 +109,8 @@
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
 
         if (this.element.is('input')) {
-            this.element.on({
+            self = this
+            self.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
                 'keyup.daterangepicker': (function(event){

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -109,12 +109,12 @@
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
 
         if (this.element.is('input')) {
-            self = this
+            var self = this
             self.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': (function(event){
-                    if(event.keyCode == 13){
+                'keydown.daterangepicker': (function(event){
+                    if(event.which == 13){
                         self.updateFromControl()
                     }
                 })

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -504,14 +504,16 @@
                 end = null;
 
             if(dateString.length === 2) {
-                start = moment(dateString[0], this.format).utcOffset(this.timeZone);
-                end = moment(dateString[1], this.format).utcOffset(this.timeZone);
+                start = moment(dateString[0], this.format, true).utcOffset(this.timeZone);
+                end = moment(dateString[1], this.format, true).utcOffset(this.timeZone);
             }
 
             if (this.singleDatePicker || start === null || end === null) {
-                start = moment(this.element.val(), this.format).utcOffset(this.timeZone);
+                start = moment(this.element.val(), this.format, true).utcOffset(this.timeZone);
                 end = start;
             }
+
+            if (!start.isValid() || !end.isValid()) return;
 
             if (end.isBefore(start)) return;
 
@@ -673,7 +675,7 @@
         // when a date is typed into the start to end date textboxes
         inputsChanged: function (e) {
             var el = $(e.target);
-            var date = moment(el.val(), this.format);
+            var date = moment(el.val(), this.format, true);
             if (!date.isValid()) return;
 
             var startDate, endDate;


### PR DESCRIPTION
Found a couple bugs floating around:

1) inputs took invalid dates (e.g. "1/abc/2015" would return "1/20/0015"). Fixed by setting true in the moment object creation and checking for validity. Built off of https://github.com/dangrossman/bootstrap-daterangepicker/issues/545 which encompasses the main input but also added validation for the mini inputs.

2) When a start and end date object are the same day, it defaults them both to beginning of day essentially giving you no range for that day. Set the end to endOf('day') so that you will now get the 24hr range of the day.