### PR TITLE
opens: "embed" - always visible option, fixes #576

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $('input[name="daterange"]').daterangepicker(
 
 `ranges`: (object) Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds of the range
 
-`opens`: (string: 'left'/'right'/'center') Whether the picker appears aligned to the left, to the right, or centered under the HTML element it's attached to
+`opens`: (string: 'left'/'right'/'center'/'embed') Whether the picker appears aligned to the left, to the right, centered under or embed in the parent of the HTML element it's attached to
 
 `buttonClasses`: (array) CSS class names that will be added to all buttons in the picker
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $('input[name="daterange"]').daterangepicker(
 
 `ranges`: (object) Set predefined date ranges the user can select from. Each key is the label for the range, and its value an array with two dates representing the bounds of the range
 
-`opens`: (string: 'left'/'right'/'center'/'embed') Whether the picker appears aligned to the left, to the right, centered under or embed in the parent of the HTML element it's attached to
+`opens`: (string: 'left'/'right'/'center'/'embed') Whether the picker appears aligned to the left, to the right, centered under or embed after the HTML element it's attached to
 
 `buttonClasses`: (array) CSS class names that will be added to all buttons in the picker
 

--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -285,3 +285,17 @@
 .daterangepicker th.month {
   width: auto;
 }
+
+.daterangepicker.opensembed {
+  position: relative;
+  top: auto;
+  left: auto;
+  float: none;
+}
+
+.daterangepicker.opensembed > .calendar,
+.daterangepicker.opensembed > .ranges {
+  display: inline-block;
+  vertical-align: top;
+  margin: 5px;
+}

--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -291,6 +291,7 @@
   top: auto;
   left: auto;
   float: none;
+  z-index: auto;
 }
 
 .daterangepicker.opensembed > .calendar,

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -323,6 +323,7 @@
   top: auto;
   left: auto;
   float: none;
+  z-index: auto;
 }
 
 .daterangepicker.opensembed > .calendar,

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -317,3 +317,17 @@
 .daterangepicker th.month {
   width: auto;
 }
+
+.daterangepicker.opensembed {
+  position: relative;
+  top: auto;
+  left: auto;
+  float: none;
+}
+
+.daterangepicker.opensembed > .calendar,
+.daterangepicker.opensembed > .ranges {
+  display: inline-block;
+  vertical-align: top;
+  margin: 5px;
+}

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -573,8 +573,7 @@
                     });
                 }
             } else if (this.opens == 'embed') {                
-                this.element.parent().append(this.container);
-                this.element.hide();
+                this.element.after(this.container);
             } else {
                 this.container.css({
                     top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -433,6 +433,10 @@
                 }
             }
 
+            if (this.opens == 'embed') {
+                this.show();
+            }
+
             if (typeof options.ranges === 'undefined' && !this.singleDatePicker) {
                 this.container.addClass('show-calendar');
             }
@@ -568,6 +572,9 @@
                         left: 9
                     });
                 }
+            } else if (this.opens == 'embed') {                
+                this.element.parent().append(this.container);
+                this.element.hide();
             } else {
                 this.container.css({
                     top: this.element.offset().top + this.element.outerHeight() - parentOffset.top,
@@ -629,7 +636,7 @@
         },
 
         hide: function (e) {
-            if (!this.isShowing) return;
+            if (!this.isShowing || (this.opens == 'embed')) return;
 
             $(document)
               .off('.daterangepicker');


### PR DESCRIPTION
Hi,

I've added a new value for `opens` option - `embed`.

If you choose this option, then:
* the widget will be shown on init
* the hide function will be disabled
* the widget container will be appended after the HTML component it's attached to
* the CSS styles will remove float and position absolute, to make the widget resize normally

I know you did not plan to implement this, but maybe you could accept this PR? If you don't use it, it will not change anything.