### PR TITLE
Fix unwanted endDate modifying maxDate.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -771,7 +771,7 @@
                 var difference = this.endDate.diff(this.startDate);
                 endDate = moment(startDate).add(difference, 'ms');
                 if (this.maxDate && endDate.isAfter(this.maxDate)) {
-                  endDate = this.maxDate;
+                  endDate = this.maxDate.clone();
                 }
             }
             this.startDate = startDate;


### PR DESCRIPTION
Whenever endDate becomes bigger than maxDate, it is set to maxDate without cloning the object. This results in maxDate being modified every time endDate is updated.