### PR TITLE
Call updateInputText() from setCustomDates()

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -779,6 +779,7 @@
 
             this.updateView();
             this.updateCalendars();
+            this.updateInputText();
         },
 
         clickDate: function (e) {


### PR DESCRIPTION
This keeps the input element synchronized when the user clicks a date on a calendar, but doesn't click the apply button. Related to #332