### PR TITLE
Set atribute type button for html button to prevent form submit.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -57,8 +57,8 @@
                       '<label for="daterangepicker_end"></label>' +
                       '<input class="input-mini" type="text" name="daterangepicker_end" value="" />' +
                     '</div>' +
-                    '<button class="applyBtn" disabled="disabled"></button>&nbsp;' +
-                    '<button class="cancelBtn"></button>' +
+                    '<button class="applyBtn" disabled="disabled" type="button"></button>&nbsp;' +
+                    '<button class="cancelBtn" type="button"></button>' +
                   '</div>' +
                 '</div>' +
               '</div>';


### PR DESCRIPTION
<button> will implicitly submit, which can cause problems if you want to use a button in a form without it submitting. So I think buttons should have attribute type="button".