### PR TITLE
Problem: sometimes it is needed to react right after the user selects…

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Several events are triggered on the element you attach the picker to, which you 
 
 `cancel.daterangepicker`: Triggered when the cancel button is clicked
 
+`clickDate.daterangepicker`: Triggered when a date in calendar is clicked
+
 Some applications need a "clear" instead of a "cancel" functionality, which can be achieved by changing the button label and watching for the cancel event:
 
 ````

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -849,6 +849,8 @@
 
             if (this.singleDatePicker && !this.timePicker)
                 this.clickApply();
+
+            this.element.trigger('clickDate.daterangepicker', this);
         },
 
         clickApply: function (e) {


### PR DESCRIPTION
… a date, before he clicks on apply button

Solution: 
- trigger the ‘clickDate.daterangepicker’ event in clickDate function
- update Readme to document that behaviour