### PR TITLE
Allows singleDatePicker to appear left, right or centered

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -380,7 +380,7 @@
             }
 
             if (this.singleDatePicker) {
-                this.opens = 'right';
+                this.opens = this.opens || 'right';
                 this.container.addClass('single');
                 this.container.find('.calendar.right').show();
                 this.container.find('.calendar.left').hide();


### PR DESCRIPTION
This allows the picker to be aligned on a direction other than the default right