### PR TITLE
Localization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $('input[name="daterange"]').daterangepicker(
 
 `separator`: (string) Separator string to display between the start and end date when populating a text input the picker is attached to
 
-`locale`: (object) Allows you to provide localized strings for buttons and labels, and the first day of week for the calendars
+`locale`: (object or string) Allows you to provide localized strings for buttons and labels, and the first day of week for the calendars. If option is String, it should be a correct locale name (e.g. 'en', 'ru', 'ja', etc). Or it should be equal to 'moment' in order to use momentjs locale.
 
 `singleDatePicker`: (boolean) Show only a single calendar to choose one date, instead of a range picker with two calendars; the start and end dates provided to your callback will be the same single date chosen
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -143,17 +143,38 @@
             this.format = 'MM/DD/YYYY';
             this.separator = ' - ';
 
-            this.locale = {
+            this.locales = {
+              'en': {
                 applyLabel: 'Apply',
                 cancelLabel: 'Cancel',
                 fromLabel: 'From',
                 toLabel: 'To',
                 weekLabel: 'W',
                 customRangeLabel: 'Custom Range',
+              },
+              'ru': {
+                applyLabel: 'Применить',
+                cancelLabel: 'Отмена',
+                fromLabel: 'От',
+                toLabel: 'До',
+                weekLabel: 'Нед.',
+                customRangeLabel: 'Свой диапазон',
+              },
+              'ja': {
+                applyLabel: '適用します',
+                cancelLabel: 'キャンセル',
+                fromLabel: 'より',
+                toLabel: 'へ',
+                weekLabel: '週',
+                customRangeLabel: '独自の範囲。',
+              }
+            }
+
+            this.locale = $.extend({
                 daysOfWeek: moment.weekdaysMin(),
                 monthNames: moment.monthsShort(),
                 firstDay: moment.localeData()._week.dow
-            };
+            }, this.locales.en);
 
             this.cb = function () { };
 
@@ -235,6 +256,13 @@
                 if (typeof options.locale.customRangeLabel === 'string') {
                   this.locale.customRangeLabel = options.locale.customRangeLabel;
                 }
+            } else if (typeof options.locale === 'string') {
+              // 'en' is failsafe locale
+              $.extend(this.locale, this.locales[
+                options.locale === 'moment'
+                ? moment.locale()
+                : options.locale
+              ] || {});
             }
 
             if (typeof options.opens === 'string')

--- a/examples.html
+++ b/examples.html
@@ -9,6 +9,8 @@
       <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
       <script type="text/javascript" src="http://netdna.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
       <script type="text/javascript" src="moment.js"></script>
+      <script type="text/javascript" src="node_modules/moment/min/locales.min.js"></script>
+      <script type="text/javascript">moment.locale('en')</script>
       <script type="text/javascript" src="daterangepicker.js"></script>
    </head>
    <body>
@@ -203,6 +205,50 @@
                   $('#destroy').click(function() {
                     $('#reportrange').data('daterangepicker').remove();
                   });
+
+               });
+               </script>
+
+            </div>
+
+
+            <h4>Different Locales</h4>
+
+            <div class="well" style="overflow: auto">
+
+              <div class="alert alert-warning" role="alert">
+                <b>Warning!</b> Localization highly depend on moment.locale(). Be sure you've configure momentjs properly!.
+              </div>
+
+              <button class="btn btn-primary" onclick="setLocale('en')">English</button>
+              <button class="btn btn-primary" onclick="setLocale('ru')">Русский</button>
+              <button class="btn btn-primary" onclick="setLocale('ja')">日本語</button>
+
+               <div id="picker-localized" class="btn pull-right" style="display: inline-block; background: #fff; cursor: pointer; padding: 5px 10px; border: 1px solid #ccc">
+                  <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>
+                  <span></span> <b class="caret"></b>
+               </div>
+
+               <script type="text/javascript">
+               $(document).ready(function() {
+
+                  var config = {
+                    ranges: {},
+                    showWeekNumbers: true,
+                    opens: 'left',
+                    locale: 'moment'
+                  }
+
+                  var picker = $('#picker-localized');
+                  picker.daterangepicker();
+
+                  window.setLocale = function(locale) {
+                    moment.locale(locale);
+                    picker.data('daterangepicker').setOptions(config);
+                    picker.find('span').html(moment().subtract(29, 'days').format('MMMM D, YYYY') + ' - ' + moment().format('MMMM D, YYYY'));
+                  }
+
+                  setLocale('en')
 
                });
                </script>


### PR DESCRIPTION
I've just implemented better localization options for the widget.
Now `options.locale` accepts:
* `Object : [locale object]` - old approach to set locale
* `String : 'moment'` - use locale described in `moment.locale()`. Locales for momentjs should be included to your app separately, or you can use complete momentjs bundle with all locales.
* `String : like 'en', 'ru', 'ja', etc` - use specified locale. I've added only locales for russian (my native lang.) and japanese (translated by google). Also, this approach does not affect momentjs, so names of the days/months will not be translated.
![calendar-localization](https://cloud.githubusercontent.com/assets/1101771/7714104/ae182d3e-fe84-11e4-93e7-d8a5820a036e.png)
