### PR TITLE
[FIX] calendars are stacked inverted #225

### DIFF
--- a/daterangepicker-bs2.css
+++ b/daterangepicker-bs2.css
@@ -19,7 +19,7 @@
 
 .daterangepicker.opensright .ranges, .daterangepicker.opensright .calendar,
 .daterangepicker.openscenter .ranges, .daterangepicker.openscenter .calendar {
-  float: right;
+  float: left;
   margin: 4px;
 }
 

--- a/daterangepicker-bs3.css
+++ b/daterangepicker-bs3.css
@@ -19,7 +19,7 @@
 
 .daterangepicker.opensright .ranges, .daterangepicker.opensright .calendar,
 .daterangepicker.openscenter .ranges, .daterangepicker.openscenter .calendar {
-  float: right;
+  float: left;
   margin: 4px;
 }
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -433,9 +433,6 @@
                     first.addClass('single');
                 }
 
-                first.removeClass('left').addClass('right');
-                second.removeClass('right').addClass('left');
-
                 if (this.singleDatePicker) {
                     first.show();
                     second.hide();


### PR DESCRIPTION
This is an attempt to fix issue #225.
This fix is tested on Chrome 44 and IOS7.

![2015-06-30_12 25 27](https://cloud.githubusercontent.com/assets/452941/8428991/dfa15564-1f23-11e5-8b98-7f2fcd7ee696.png)

Also tested on Firefox 38 but Firefox don't stack calendars at all.

A side effect is that predefined ranges move to the right as shown in the following screenshot.
![2015-06-30_12 27 59](https://cloud.githubusercontent.com/assets/452941/8428954/78750d40-1f23-11e5-8bb3-c0120fd359cd.png)


