### PR TITLE
Considering horizontal scroll when opening the datepicker from body

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -571,6 +571,8 @@
                     left: this.parentEl.offset().left - this.parentEl.scrollLeft()
                 };
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
+            } else {
+              parentRightEdge += $(window).scrollLeft();
             }
             
             if (this.drops == 'up')


### PR DESCRIPTION
When scrolling left-right the datepicker is not keeping a consisent position when hooked to the body. With this fix it is considering also the scroll position.