### PR TITLE
Allow the range labels displayed to differ from the keys identifying the ranges

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -362,14 +362,16 @@
                     }
 
                     this.ranges[range] = [start, end];
+                    
+                    if(typeof options.ranges[range][2] === 'string')
+                    	this.ranges[range].push(options.ranges[range][2]);
                 }
 
-                var list = '<ul>';
+                var list = $('<ul></ul>');
                 for (range in this.ranges) {
-                    list += '<li>' + range + '</li>';
+                    $('<li>' + (typeof this.ranges[range][2] === 'string' ? this.ranges[range][2] : range) + '</li>').data('rangeKey', range).appendTo(list);
                 }
-                list += '<li>' + this.locale.customRangeLabel + '</li>';
-                list += '</ul>';
+               $('<li>' + this.locale.customRangeLabel + '</li>').appendTo(list);
                 this.container.find('.ranges ul').remove();
                 this.container.find('.ranges').prepend(list);
             }
@@ -650,8 +652,8 @@
 
         enterRange: function (e) {
             // mouse pointer has entered a range label
-            var label = e.target.innerHTML;
-            if (label == this.locale.customRangeLabel) {
+            var label = $(e.target).data('rangeKey');
+            if (!label) {
                 this.updateView();
             } else {
                 var dates = this.ranges[label];
@@ -704,9 +706,9 @@
         },
 
         clickRange: function (e) {
-            var label = e.target.innerHTML;
-            this.chosenLabel = label;
-            if (label == this.locale.customRangeLabel) {
+            var label = $(e.target).data('rangeKey');
+            this.chosenLabel = label || this.locale.customRangeLabel;
+            if (!label) {
                 this.showCalendars();
             } else {
                 var dates = this.ranges[label];
@@ -911,20 +913,20 @@
                     if (this.startDate.isSame(this.ranges[range][0]) && this.endDate.isSame(this.ranges[range][1])) {
                         customRange = false;
                         this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')')
-                            .addClass('active').html();
+                            .addClass('active').data('rangeKey') || this.locale.customRangeLabel;
                     }
                 } else {
                     //ignore times when comparing dates if time picker is not enabled
                     if (this.startDate.format('YYYY-MM-DD') == this.ranges[range][0].format('YYYY-MM-DD') && this.endDate.format('YYYY-MM-DD') == this.ranges[range][1].format('YYYY-MM-DD')) {
                         customRange = false;
                         this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')')
-                            .addClass('active').html();
+                            .addClass('active').data('rangeKey') || this.locale.customRangeLabel;
                     }
                 }
                 i++;
             }
             if (customRange) {
-                this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
+                this.chosenLabel = this.container.find('.ranges li:last').addClass('active').data('rangeKey') || this.locale.customRangeLabel;
                 this.showCalendars();
             }
         },


### PR DESCRIPTION
The reason for this update is the need to be able to remember user's selection based on the selected range's key ("Today", "Yesterday", etc.) while still allowing the range label's text to be translated (and display like "Hoy", "Ayer", etc.).

Usage
--------------
This feature is used by adding a third element to the range's array which is to be used as the label (if the element is not provided then the key will be used as usual):
```javascript
ranges: {
       'Today': [moment(), moment(), 'Hoy'],
       'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days'), 'Ayer']
    }
```
This way the user's selection of "Hoy" will be reported to the callbacks as "Today" and can be saved this way. Working with range keys instead of translated strings is much easier and more reliable.
