### PR TITLE
allow fireCallback to be called externally

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -20,7 +20,7 @@
       jQuery = require('jquery');
     } catch (err) {
       jQuery = window.jQuery;
-      if (!jQuery) throw new Error('jQuery dependnecy not found');
+      if (!jQuery) throw new Error('jQuery dependency not found');
     }
 
     factory(root, exports, momentjs, jQuery);
@@ -99,7 +99,7 @@
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini" type="text" name="daterangepicker_start" value="" />' +
                       '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
-                      '<div class="calendar-time">' + 
+                      '<div class="calendar-time">' +
                         '<div></div>' +
                         '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
                       '</div>' +
@@ -110,7 +110,7 @@
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini" type="text" name="daterangepicker_end" value="" />' +
                       '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
-                      '<div class="calendar-time">' + 
+                      '<div class="calendar-time">' +
                         '<div></div>' +
                         '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
                       '</div>' +
@@ -213,7 +213,7 @@
 
         if (typeof options.showDropdowns === 'boolean')
             this.showDropdowns = options.showDropdowns;
-        
+
         if (typeof options.singleDatePicker === 'boolean') {
             this.singleDatePicker = options.singleDatePicker;
             if (this.singleDatePicker)
@@ -305,7 +305,7 @@
                 if (maxDate && end.isAfter(maxDate))
                     end = maxDate.clone();
 
-                // If the end of the range is before the minimum or the start of the range is 
+                // If the end of the range is before the minimum or the start of the range is
                 // after the maximum, don't display this range option at all.
                 if ((this.minDate && end.isBefore(this.minDate)) || (maxDate && start.isAfter(maxDate)))
                     continue;
@@ -722,7 +722,7 @@
                 for (var col = 0; col < 7; col++) {
 
                     var classes = [];
-                    
+
                     //highlight today's date
                     if (calendar[row][col].isSame(new Date(), "day"))
                         classes.push('today');
@@ -778,7 +778,7 @@
         },
 
         renderTimePicker: function(side) {
-  
+
             var selected, minDate, maxDate = this.maxDate;
 
             if (this.dateLimit && (!this.maxDate || this.startDate.clone().add(this.dateLimit).isAfter(this.maxDate)))
@@ -791,7 +791,7 @@
                 selected = this.endDate ? this.endDate.clone() : this.startDate.clone();
                 minDate = this.startDate;
             }
- 
+
             //
             // hours
             //
@@ -932,7 +932,7 @@
                 };
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
             }
-            
+
             if (this.drops == 'up')
                 containerTop = this.element.offset().top - this.container.outerHeight() - parentOffset.top;
             else
@@ -996,7 +996,7 @@
 
             this.oldStartDate = this.startDate.clone();
             this.oldEndDate = this.endDate.clone();
- 
+
             this.updateView();
             this.container.show();
             this.move();
@@ -1015,7 +1015,7 @@
 
             //if a new date range was selected, invoke the user callback function
             if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
-                this.callback(this.startDate, this.endDate, this.chosenLabel);
+                this.fireCallback();
 
             //if picker is attached to a text input, update it
             if (this.element.is('input') && !this.singleDatePicker) {
@@ -1038,6 +1038,10 @@
             } else {
                 this.show();
             }
+        },
+
+        fireCallback: function(e) {
+            this.callback(this.startDate, this.endDate, this.chosenLabel);
         },
 
         outsideClick: function(e) {
@@ -1339,7 +1343,7 @@
             this.setEndDate(end);
             this.updateView();
         },
-        
+
         keydown: function(e) {
             //hide on tab or enter
             if ((e.keyCode === 9) || (e.keyCode === 13)) {


### PR DESCRIPTION
I noticed there was no way to "externally" fire the callback. So when I had a custom callback function, I could not call it directly from javascript. I wanted to be able to do:

$('#element').data('daterangepicker').fireCallback();

I'm open to other solutions, but basically the problem was such that when I had a custom callback, it was not being fired on initial "setup" of the plugin, and also not fired on subsequent method calls like setStartDate since they were not going through the normal plugin process of render calendar/update selection/hide calendar.

Also, minor spacing cleanup.