### PR TITLE
add before show event

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -999,7 +999,10 @@
 
         show: function(e) {
             if (this.isShowing) return;
-
+            
+            // Allow for reconfigure prior to display.
+            this.element.trigger('before.daterangepicker', this);
+            
             // Create a click proxy that is private to this instance of datepicker, for unbinding
             this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
             // Bind global datepicker mousedown for hiding and


### PR DESCRIPTION
allows you to completely reconfig the widget right before showing if needed. our form is two fields, and i needed to be able to change settings of each when activated. an example resetting the maxDate prior:

InputStart.on('before.daterangepicker',function(e,picker){ picker.maxDate = moment(InputEnd.val(),picker.locale.format); });