### PR TITLE
Feature/is invalid date

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -248,8 +248,8 @@
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
 
-        if (typeof options.isInvalidDay === 'function')
-            this.isInvalidDay = options.isInvalidDay;
+        if (typeof options.isInvalidDate === 'function')
+            this.isInvalidDate = options.isInvalidDate;
 
 
         // update day names order to firstDay
@@ -486,7 +486,7 @@
             this.updateMonthsInView();
         },
 
-        isInvalidDay: function() {
+        isInvalidDate: function() {
             return false;
         },
 
@@ -778,7 +778,7 @@
                         classes.push('off', 'disabled');
 
                     //don't allow selection of date if a custom function decides it's invalid
-                    if (this.isInvalidDay(calendar[row][col]))
+                    if (this.isInvalidDate(calendar[row][col]))
                         classes.push('off', 'disabled');
 
                     //highlight the currently selected start date

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -248,6 +248,10 @@
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
 
+        if (typeof options.isInvalidDay === 'function')
+            this.isInvalidDay = options.isInvalidDay;
+
+
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -480,6 +484,10 @@
                 this.endDate = this.startDate.clone().add(this.dateLimit);
 
             this.updateMonthsInView();
+        },
+
+        isInvalidDay: function() {
+            return false;
         },
 
         updateView: function() {
@@ -767,6 +775,10 @@
 
                     //don't allow selection of dates after the maximum date
                     if (maxDate && calendar[row][col].isAfter(maxDate, 'day'))
+                        classes.push('off', 'disabled');
+
+                    //don't allow selection of date if a custom function decides it's invalid
+                    if (this.isInvalidDay(calendar[row][col]))
                         classes.push('off', 'disabled');
 
                     //highlight the currently selected start date


### PR DESCRIPTION
Recreating this PR against v2 of daterangepicker.


Analogous to jquery-ui's onBeforeDay option, this lets users set a method to determine if individual days are invalid (weekends, holidays, etc). For example

$('input[name="daterange"]').daterangepicker({
   isInvalidDate: function(day) {
      if (day.day() === 0 || day.day() === 6) {
         return false;
      } else {
         return true;
      }
   }
});
will block out all Sunday and Saturdays