### PR TITLE
fix opens right so the dropdown-menu is actually aligned to the right

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -75,7 +75,7 @@
 .daterangepicker.opensright:before {
   position: absolute;
   top: -7px;
-  left: 9px;
+  right: 9px;
   display: inline-block;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #ccc;
@@ -87,7 +87,7 @@
 .daterangepicker.opensright:after {
   position: absolute;
   top: -6px;
-  left: 10px;
+  right: 10px;
   display: inline-block;
   border-right: 6px solid transparent;
   border-bottom: 6px solid #fff;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -993,7 +993,7 @@
             } else {
                 this.container.css({
                     top: containerTop,
-                    left: this.element.offset().left - parentOffset.left,
+                    left: this.element.offset().left - parentOffset.left + this.element.outerWidth() - this.container.outerWidth(),
                     right: 'auto'
                 });
                 if (this.container.offset().left + this.container.outerWidth() > $(window).width()) {


### PR DESCRIPTION
Setting opens to 'right' while creating the daterangepicker did not have the intended effect as the daterangepicker was aligned to the left nevertheless. This can be seen using the Configuration Generator on your website as well.

![open-right-bug](https://cloud.githubusercontent.com/assets/1702075/9211825/ce706dd4-4084-11e5-9e9f-9a6a08d079c6.png)

This pull request fixes this behaviour and the daterangepicker will be aligned to the right es expected when setting opens to 'right'.

![image](https://cloud.githubusercontent.com/assets/1702075/9211939/7dd192bc-4085-11e5-94bb-81646cbc5fca.png)
