### PR TITLE
Enhancement make it possible to determine if ranges appear on the right or left side of calendars

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -64,6 +64,8 @@
         if (this.element.hasClass('dropup'))
             this.drops = 'up';
 
+        this.rangesPositionInRelationToCalendars = 'after';
+
         this.buttonClasses = 'btn btn-sm';
         this.applyClass = 'btn-success';
         this.cancelClass = 'btn-default';
@@ -95,15 +97,20 @@
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
 
+        if (typeof options.rangesPositionInRelationToCalendars === 'string')
+            this.rangesPositionInRelationToCalendars = options.rangesPositionInRelationToCalendars;
+
         //html template for the picker UI
-        if (typeof options.template !== 'string')
-            options.template = '<div class="daterangepicker dropdown-menu">' +
-                '<div class="ranges">' +
-                    '<div class="range_inputs">' +
-                        '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
-                        '<button class="cancelBtn" type="button"></button>' +
-                    '</div>' +
+        if (typeof options.template !== 'string') {
+            var rangesTemplate = '<div class="ranges">' +
+                '<div class="range_inputs">' +
+                    '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
+                    '<button class="cancelBtn" type="button"></button>' +
                 '</div>' +
+            '</div>';
+
+            options.template = '<div class="daterangepicker dropdown-menu">' +
+                ((this.rangesPositionInRelationToCalendars === 'before') ? rangesTemplate : '') +
                 '<div class="calendar left">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini" type="text" name="daterangepicker_start" value="" />' +
@@ -126,7 +133,9 @@
                     '</div>' +
                     '<div class="calendar-table"></div>' +
                 '</div>' +
+                ((this.rangesPositionInRelationToCalendars === 'after') ? rangesTemplate : '') +
             '</div>';
+        }
 
         this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(options.template).appendTo(this.parentEl);

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -98,6 +98,12 @@
         //html template for the picker UI
         if (typeof options.template !== 'string')
             options.template = '<div class="daterangepicker dropdown-menu">' +
+                '<div class="ranges">' +
+                    '<div class="range_inputs">' +
+                        '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
+                        '<button class="cancelBtn" type="button"></button>' +
+                    '</div>' +
+                '</div>' +
                 '<div class="calendar left">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini" type="text" name="daterangepicker_start" value="" />' +
@@ -119,12 +125,6 @@
                       '</div>' +
                     '</div>' +
                     '<div class="calendar-table"></div>' +
-                '</div>' +
-                '<div class="ranges">' +
-                    '<div class="range_inputs">' +
-                        '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
-                        '<button class="cancelBtn" type="button"></button>' +
-                    '</div>' +
                 '</div>' +
             '</div>';
 

--- a/demo.html
+++ b/demo.html
@@ -149,6 +149,14 @@
               </div>
 
               <div class="form-group">
+                <label for="rangesPositionInRelationToCalendars">rangesPositionInRelationToCalendars</label>
+                <select id="rangesPositionInRelationToCalendars" class="form-control">
+                  <option value="after" selected>after</option>
+                  <option value="before">before</option>
+                </select>
+              </div>
+
+              <div class="form-group">
                 <label for="buttonClasses">buttonClasses</label>
                 <input type="text" class="form-control" id="buttonClasses" value="btn btn-sm">
               </div>
@@ -306,6 +314,9 @@
 
           if ($('#drops').val().length && $('#drops').val() != 'down')
             options.drops = $('#drops').val();
+
+          if ($('#rangesPositionInRelationToCalendars').val().length && $('#rangesPositionInRelationToCalendars').val() != 'after')
+            options.rangesPositionInRelationToCalendars = $('#rangesPositionInRelationToCalendars').val();
 
           if ($('#buttonClasses').val().length && $('#buttonClasses').val() != 'btn btn-sm')
             options.buttonClasses = $('#buttonClasses').val();

--- a/website/index.html
+++ b/website/index.html
@@ -560,6 +560,9 @@
                                 <code>drops</code>: (string</code>: 'down' or 'up') Whether the picker appears below (default) or above the HTML element it's attached to
                             </li>
                             <li>
+                                <code>rangesPositionInRelationToCalendars</code>: (string</code>: 'after' or 'before') Whether the predefined date ranges the user can select from appear after (default) or before the HTML elements for the calendars
+                            </li>
+                            <li>
                                 <code>buttonClasses</code>: (array) CSS class names that will be added to all buttons in the picker
                             </li>
                             <li>

--- a/website/index.html
+++ b/website/index.html
@@ -468,6 +468,14 @@
                               </div>
 
                               <div class="form-group">
+                                <label for="rangesPositionInRelationToCalendars">rangesPositionInRelationToCalendars</label>
+                                <select id="rangesPositionInRelationToCalendars" class="form-control">
+                                  <option value="after" selected>after</option>
+                                  <option value="before">before</option>
+                                </select>
+                              </div>
+
+                              <div class="form-group">
                                 <label for="buttonClasses">buttonClasses</label>
                                 <input type="text" class="form-control" id="buttonClasses" value="btn btn-sm">
                               </div>

--- a/website/website.js
+++ b/website/website.js
@@ -107,6 +107,9 @@ $(document).ready(function() {
       if ($('#drops').val().length && $('#drops').val() != 'down')
         options.drops = $('#drops').val();
 
+      if ($('#rangesPositionInRelationToCalendars').val().length && $('#rangesPositionInRelationToCalendars').val() != 'after')
+        options.rangesPositionInRelationToCalendars = $('#rangesPositionInRelationToCalendars').val();
+
       if ($('#buttonClasses').val().length && $('#buttonClasses').val() != 'btn btn-sm')
         options.buttonClasses = $('#buttonClasses').val();
 


### PR DESCRIPTION
The changes add a new option named rangesPositionInRelationToCalendars that allows the user to determine the position of the ranges section in relation to the calendars. The position can be *'after'* (default option) or *'before'* the calendars

This change was introduced because when the date range selector is on the left it is confusing for users to open the select range, see the default ranges, click on custom range and have all the ranges be pushed to the right by the calendars that appear. This is only a problem when the date range picker is on the left of the application and it opens to the right and it has ranges.

## Current behaviour:

* User clicks on the input for the date range picker to open: 
![screen shot 2015-08-28 at 12 23 41](https://cloud.githubusercontent.com/assets/155017/9544638/c3d725a6-4d82-11e5-9992-889aefce6037.png)


* User clicks on custom (the calendar pushes the ranges to the left):
![current_behaviour](https://cloud.githubusercontent.com/assets/155017/9544694/15b7bcd2-4d83-11e5-902f-4534f6ed5bc1.png)

## New behaviour
Value for rangesPositionInRelationToCalendars is configured to *'before'*:

* Again user clicks on the input for the date range picker to open: 
![screen shot 2015-08-28 at 12 23 41](https://cloud.githubusercontent.com/assets/155017/9544643/cab92a4a-4d82-11e5-8303-db7be227e738.png)


* User clicks on custom. The calendars appear on the right of the range. No content is pushed:
![new_behaviour](https://cloud.githubusercontent.com/assets/155017/9544690/10067468-4d83-11e5-9be0-d5d86ea0f8c0.png)
