### PR TITLE
Adds option to display the dates identified by ranges

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "pcr-bootstrap-daterangepicker",
+  "version": "2.0.9.pcr",
   "main": [
     "daterangepicker.js",
     "daterangepicker.css"

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "bootstrap-daterangepicker",
+  "name": "pcr-bootstrap-daterangepicker",
   "main": [
     "daterangepicker.js",
     "daterangepicker.css"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "pcr-bootstrap-daterangepicker",
-  "version": "2.0.9.pcr",
   "main": [
     "daterangepicker.js",
     "daterangepicker.css"

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -335,9 +335,9 @@
 
             var list = '<ul>';
             for (range in this.ranges) {
-                list += '<li>' + range + '</li>';
+                list += '<li data-range-label="' + range + '">' + range + '</li>';
             }
-            list += '<li>' + this.locale.customRangeLabel + '</li>';
+            list += '<li data-range-label="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             list += '</ul>';
             this.container.find('.ranges ul').remove();
             this.container.find('.ranges').prepend(list);
@@ -1118,7 +1118,11 @@
         },
 
         hoverRange: function(e) {
-            var label = e.target.innerHTML;
+            var $el = $(e.target);
+            if ($(e.target).prop('tagName') !== 'LI') {
+                $el = $el.parents('li');
+            }
+            var label = $el.data('range-label');
             if (label == this.locale.customRangeLabel) {
                 this.updateView();
             } else {
@@ -1129,7 +1133,11 @@
         },
 
         clickRange: function(e) {
-            var label = e.target.innerHTML;
+            var $el = $(e.target);
+            if ($(e.target).prop('tagName') !== 'LI') {
+                $el = $el.parents('li');
+            }
+            var label = $el.data('range-label');
             this.chosenLabel = label;
             if (label == this.locale.customRangeLabel) {
                 this.showCalendars();

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -55,6 +55,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.ranges = {};
+        this.showLabelRangeDates = false;
 
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
@@ -252,6 +253,9 @@
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
 
+        if (typeof options.showLabelRangeDates === 'boolean')
+            this.showLabelRangeDates = options.showLabelRangeDates;
+
         if (typeof options.isInvalidDate === 'function')
             this.isInvalidDate = options.isInvalidDate;
 
@@ -334,8 +338,21 @@
             }
 
             var list = '<ul>';
-            for (range in this.ranges) {
-                list += '<li data-range-label="' + range + '">' + range + '</li>';
+            if (this.showLabelRangeDates) {
+                for (range in this.ranges) {
+                    list += '<li data-range-label="' + range + '">';
+                    list += range;
+                    list += '<br><em><small>';
+                    list += this.ranges[range][0].format(this.locale.format);
+                    list += ' - ';
+                    list += this.ranges[range][1].format(this.locale.format);
+                    list += '</small></em>';
+                    list += '</li>';
+                }
+            } else {
+                for (range in this.ranges) {
+                    list += '<li data-range-label="' + range + '">' + range + '</li>';
+                }
             }
             list += '<li data-range-label="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             list += '</ul>';

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'dangrossman:bootstrap-daterangepicker',
-  version: '2.0.9',
+  name: 'pcragone:pcr-bootstrap-daterangepicker',
+  version: '2.0.9.pcr',
   summary: 'Date range picker component for Bootstrap',
-  git: 'https://github.com/dangrossman/bootstrap-daterangepicker',
+  git: 'https://github.com/pcragone/bootstrap-daterangepicker',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'pcragone:pcr-bootstrap-daterangepicker',
-  version: '2.0.9.pcr',
+  version: '2.0.10',
   summary: 'Date range picker component for Bootstrap',
   git: 'https://github.com/pcragone/bootstrap-daterangepicker',
   documentation: 'README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bootstrap-daterangepicker",
-  "version": "2.0.9",
+  "name": "pcr-bootstrap-daterangepicker",
+  "version": "2.0.9.pcr",
   "description": "Date range picker component for Bootstrap",
   "main": "daterangepicker.js",
   "style": "daterangepicker.css",
@@ -9,18 +9,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dangrossman/bootstrap-daterangepicker.git"
+    "url": "https://github.com/pcragone/bootstrap-daterangepicker.git"
   },
   "author": {
-    "name": "Dan Grossman",
-    "email": "dan@dangrossman.info",
-    "url": "http://www.dangrossman.info"
+    "name": "Peter Ragone",
+    "email": "pcragone@gmail.com"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dangrossman/bootstrap-daterangepicker/issues"
+    "url": "https://github.com/pcragone/bootstrap-daterangepicker/issues"
   },
-  "homepage": "https://github.com/dangrossman/bootstrap-daterangepicker",
+  "homepage": "https://github.com/pcragone/bootstrap-daterangepicker",
   "dependencies": {
     "jquery": "^1.10",
     "moment": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcr-bootstrap-daterangepicker",
-  "version": "2.0.9.pcr",
+  "version": "2.0.10",
   "description": "Date range picker component for Bootstrap",
   "main": "daterangepicker.js",
   "style": "daterangepicker.css",


### PR DESCRIPTION
These commits add an option, called `showLabelRangeDates`, that displays a second line underneath the range labels identifying the ranges specified by the range label.

For example, with these settings:
```
  "showLabelRangeDates": true,
  "ranges": {
    "Today": [
      moment().startOf('day'),
      moment().endOf('day')
    ],
    "Yesterday": [
      moment().subtract(1, 'day').startOf('day'),
      moment().subtract(1, 'day').endOf('day')
    ],
    "Last 7 Days": [
      moment().subtract(1, 'week').startOf('day'),
      moment().endOf('day')
    ],
    "Last 30 Days": [
      moment().subtract(30, 'day').startOf('day'),
      moment().endOf('day')
    ],
    "This Month": [
      moment().startOf('month'),
      moment().endOf('month')
    ],
    "Last Month": [
      moment().subtract(1, 'month').startOf('month'),
      moment().subtract(1, 'month').endOf('month')
    ]
  }
```

The following text would be produced:
![image](https://cloud.githubusercontent.com/assets/1450380/9705090/ea022928-5486-11e5-9477-6e8a0416294b.png)
