### PR TITLE
Declare `html` var. 

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -831,7 +831,7 @@
 
         renderTimePicker: function(side) {
 
-            var selected, minDate, maxDate = this.maxDate;
+            var html, selected, minDate, maxDate = this.maxDate;
 
             if (this.dateLimit && (!this.maxDate || this.startDate.clone().add(this.dateLimit).isAfter(this.maxDate)))
                 maxDate = this.startDate.clone().add(this.dateLimit);


### PR DESCRIPTION
This undeclared variable causes an error if this file is included in strict environments. Also, the undeclared variable was leaking data into the global context.