### PR TITLE
only use `this` if it exists

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -32,7 +32,7 @@
     root.daterangepicker = factory(root, {}, root.moment || moment, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
-}(this, function(root, daterangepicker, moment, $) {
+}(this || {}, function(root, daterangepicker, moment, $) { // 'this' doesn't exist on a server
 
     var DateRangePicker = function(element, options, cb) {
 


### PR DESCRIPTION
guard against the implicit use of window (this) which doesn't exist on a server to help with isomorphism