### PR TITLE
remove min-width to fix ff border-box issue

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -136,11 +136,9 @@
 }
 
 /* Calendars */
-
 .daterangepicker .calendar th, .daterangepicker .calendar td {
   white-space: nowrap;
   text-align: center;
-  min-width: 32px;
 }
 
 .daterangepicker .calendar-table {


### PR DESCRIPTION
fixes https://github.com/dangrossman/bootstrap-daterangepicker/issues/825

tested in chrome + FF + ie11
ie10 : width changes to 28px

What browsers are supported and do older browsers need to be 'pixel-perfect'?