### PR TITLE
Ensure that when window size changes, dropdown stays with input element

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -430,6 +430,15 @@
             this.element.trigger('change');
         }
 
+        //
+        // Verion of the move function whose this is bound to the DateRangePicker object
+        //
+
+        this._moveBoundToThis = (function (that) {
+            return function () {
+                that.move.call(that);
+            }
+        }(this));
     };
 
     DateRangePicker.prototype = {
@@ -1059,6 +1068,7 @@
             this.move();
             this.element.trigger('show.daterangepicker', this);
             this.isShowing = true;
+            $(window).on('resize', this._moveBoundToThis);
         },
 
         hide: function(e) {
@@ -1081,6 +1091,7 @@
             this.container.hide();
             this.element.trigger('hide.daterangepicker', this);
             this.isShowing = false;
+            $(window).off('resize', this._moveBoundToThis);
         },
 
         toggle: function(e) {

--- a/demo.html
+++ b/demo.html
@@ -2,7 +2,7 @@
 <html dir="ltr" lang="en-US">
    <head>
       <meta charset="UTF-8" />
-      <title>A date range picker for Bootstrap</title>
+       <meta name="viewport" content="width=device-width, initial-scale=1">      <title>A date range picker for Bootstrap</title>
       <link href="http://netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
       <link rel="stylesheet" type="text/css" media="all" href="daterangepicker.css" />
       <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
@@ -125,6 +125,12 @@
               <div class="checkbox">
                 <label>
                   <input type="checkbox" id="autoUpdateInput" checked="checked"> autoUpdateInput
+                </label>
+              </div>
+
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="useHtml5Calendar"> useHtml5Calendar
                 </label>
               </div>
 
@@ -252,7 +258,7 @@
             options.autoApply = true;
 
           if ($('#dateLimit').is(':checked'))
-            options.dateLimit = { days: 7 };
+              options.dateLimit = { days: 7 };
 
           if ($('#ranges').is(':checked')) {
             options.ranges = {
@@ -285,6 +291,9 @@
 
           if (!$('#autoUpdateInput').is(':checked'))
             options.autoUpdateInput = false;
+
+          if ($('#useHtml5Calendar').is(':checked'))
+              options.useHtml5Calendar = true;
 
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();

--- a/website/index.html
+++ b/website/index.html
@@ -448,6 +448,12 @@
                                 </label>
                               </div>
 
+                              <div class="checkbox">
+                                <label>
+                                  <input type="checkbox" id="useHtml5Calendar"> useHtml5Calendar
+                                </label>
+                              </div>
+
                             </div>
                             <div class="col-md-4">
 
@@ -590,6 +596,12 @@
                                 <code>autoUpdateInput</code>: (boolean) Indicates whether the date range picker should
                                 automatically update the value of an <code>&lt;input&gt;</code> element it's attached to
                                 at initialization and when the selected dates change.
+                            </li>
+                            <li>
+                                <code>useHtml5Calendar</code>: (boolean) Indicates whether the date range picker should
+                                hide the dropdown calendars and use HTML5 date input fields instead of text fields.
+                                This provides a better user experience on mobiles. On responsive sites, have JavaScript check
+                                the size of the window and switch on this option if it is very narrow.
                             </li>
                         </ul>
 


### PR DESCRIPTION
I am using bootstrap-daterangepicker on a responsive site, that will be used by mobile and tablet users as well as desktop users.

I found that after you've dropped down the calendars, when you then resize the window, the dropdown detaches from the input element. Same on a mobile device when you change its orientation.

This is readily reproducable on your page
http://www.daterangepicker.com/

This pull request fixed that issue. When the dropdown is shown (show function is called), a tiny handler is bound to the window.resize event. This calls move when the window resizes, which moves the dropdown back to the input element. When the dropdown is closed (hide function is called), the handler is removed.

By the way, thanks for spending the time and energy on this project. Much appreciated.
