### PR TITLE
added on focus event triggering of show() to a non-input object; when…

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -420,7 +420,10 @@
                 'keydown.daterangepicker': $.proxy(this.keydown, this)
             });
         } else {
-            this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
+            this.element.on({
+                'click.daterangepicker': $.proxy(this.toggle, this),
+                'focus.daterangepicker': $.proxy(this.show, this)
+            });
         }
 
         //


### PR DESCRIPTION
In this commit I add on focus event triggering of show(). When one adds e.g. `tabindex="0"` to the a `<div/>` one can focus on a `<div />` as well. When this `<div />` is the `<div />` the daterangepicker is attached to it makes sense to show the daterangepicker and improves keyboard navigate-ability.