### PR TITLE
added on focus event triggering of show() to a non-input object; when…

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -423,7 +423,7 @@
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'blur.daterangepicker': $.proxy(this.hide, this)
+                'keydown.daterangepicker': $.proxy(this.keydown, this)
             });
         }
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -420,7 +420,10 @@
                 'keydown.daterangepicker': $.proxy(this.keydown, this)
             });
         } else {
-            this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
+            this.element.on({
+                'click.daterangepicker': $.proxy(this.toggle, this),
+                'focus.daterangepicker': $.proxy(this.show, this)
+            });
         }
 
         //

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -571,7 +571,7 @@
                     minute = parseInt(this.container.find('.right .minuteselect').val(), 10);
                     second = this.timePickerSeconds ? parseInt(this.container.find('.right .secondselect').val(), 10) : 0;
                     if (!this.timePicker24Hour) {
-                        var ampm = this.container.find('.left .ampmselect').val();
+                        var ampm = this.container.find('.right .ampmselect').val();
                         if (ampm === 'PM' && hour < 12)
                             hour += 12;
                         if (ampm === 'AM' && hour === 12)

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -421,8 +421,9 @@
             });
         } else {
             this.element.on({
-                'click.daterangepicker': $.proxy(this.toggle, this),
-                'focus.daterangepicker': $.proxy(this.show, this)
+                'click.daterangepicker': $.proxy(this.show, this),
+                'focus.daterangepicker': $.proxy(this.show, this),
+                'blur.daterangepicker': $.proxy(this.hide, this)
             });
         }
 

--- a/demo.html
+++ b/demo.html
@@ -173,9 +173,18 @@
         <div class="row">
 
           <div class="col-md-4 col-md-offset-2 demo">
-            <h4>Your Date Range Picker</h4>
-            <input type="text" id="config-demo" class="form-control">
-            <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>
+            <div class="row">
+              <div class="col-md-12">
+                <h4>Your Date Range Picker</h4>
+                <input type="text" id="config-demo" class="form-control">
+                <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <div id="config-demo-div" class="btn" tabindex="0">Pick a range</div>
+              </div>
+            </div>
           </div>
 
           <div class="col-md-6">
@@ -319,7 +328,8 @@
           $('#config-text').val("$('#demo').daterangepicker(" + JSON.stringify(options, null, '    ') + ", function(start, end, label) {\n  console.log(\"New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')\");\n});");
 
           $('#config-demo').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); });
-          
+
+          $('#config-demo-div').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); });
         }
 
       });

--- a/demo.html
+++ b/demo.html
@@ -5,10 +5,16 @@
       <title>A date range picker for Bootstrap</title>
       <link href="http://netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
       <link rel="stylesheet" type="text/css" media="all" href="daterangepicker.css" />
-      <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+      <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
       <script type="text/javascript" src="http://netdna.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
       <script type="text/javascript" src="moment.js"></script>
       <script type="text/javascript" src="daterangepicker.js"></script>
+
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
    </head>
    <body style="margin: 60px 0">
 
@@ -276,7 +282,7 @@
 
           if ($('#locale').is(':checked')) {
             options.locale = {
-              format: 'MM/DD/YYYY',
+              format: 'MM/DD/YYYY HH:mm',
               separator: ' - ',
               applyLabel: 'Apply',
               cancelLabel: 'Cancel',

--- a/website/index.html
+++ b/website/index.html
@@ -128,7 +128,7 @@
                                     <li><a href="#ex2">Date and Time</a></li>
                                     <li><a href="#ex3">Single Date Picker</a></li>
                                     <li><a href="#ex4">Predefined Ranges</a></li>
-                                    <li><a href="#ex5">Initially Empty Input</a></li>
+                                    <li><a href="#ex5">Input Initially Empty</a></li>
                                 </ul>
                             </li>
                             <li><a href="#config">Configuration Generator</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -332,7 +332,7 @@
                                 </div>
                                 <div class="col-md-3 col-xs-12">
                                     <h4>Demo:</h4>
-                                    <input class="pull-right" type="text" name="datefilter" value="10/24/1984" />
+                                    <input class="pull-right" type="text" name="datefilter" value="" />
                                 </div>
                             </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -347,8 +347,10 @@
                                 locale: {
                                     cancelLabel: 'Clear'
                                 }
-                            }, function(start, end) {
-                                $('input[name="datefilter"]').val(start.format('MM/DD/YYYY') + ' - ' + end.format('MM/DD/YYYY'));
+                            });
+
+                            $('input[name="datefilter"]').on('apply.daterangepicker', function(ev, picker) {
+                                $('input[name="datefilter"]').val(picke.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
                             });
 
                             $('input[name="datefilter"]').on('cancel.daterangepicker', function(ev, picker) {

--- a/website/index.html
+++ b/website/index.html
@@ -345,7 +345,7 @@
                             $('input[name="datefilter"]').daterangepicker({
                                 autoUpdateInput: false,
                                 locale: {
-                                    cancelLabel: 'clear'
+                                    cancelLabel: 'Clear'
                                 }
                             }, function(start, end) {
                                 $('input[name="datefilter"]').val(start.format('MM/DD/YYYY') + ' - ' + end.format('MM/DD/YYYY'));

--- a/website/index.html
+++ b/website/index.html
@@ -350,7 +350,7 @@
                             });
 
                             $('input[name="datefilter"]').on('apply.daterangepicker', function(ev, picker) {
-                                $('input[name="datefilter"]').val(picke.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+                                $('input[name="datefilter"]').val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
                             });
 
                             $('input[name="datefilter"]').on('cancel.daterangepicker', function(ev, picker) {

--- a/website/index.html
+++ b/website/index.html
@@ -128,6 +128,7 @@
                                     <li><a href="#ex2">Date and Time</a></li>
                                     <li><a href="#ex3">Single Date Picker</a></li>
                                     <li><a href="#ex4">Predefined Ranges</a></li>
+                                    <li><a href="#ex5">Initially Empty Input</a></li>
                                 </ul>
                             </li>
                             <li><a href="#config">Configuration Generator</a></li>
@@ -314,29 +315,52 @@
 
                         </div>
 
+                        <div id="ex5" name="ex5">
+
+                            <h3>Input Initially Empty</h3>
+
+                            <p>
+                                If you're using a date range as a filter, you may want to attach a picker to an 
+                                input but leave it empty by default. This example shows how to accomplish that
+                                using the <code>autoUpdateInput</code> setting, and the <code>apply</code> and 
+                                <code>cancel</code> events.
+                            </p>
+
+                            <div class="row">
+                                <div class="col-md-9 col-xs-12">
+                                    <script src="https://gist.github.com/dangrossman/de22909c4d24f3f3508c.js"></script>
+                                </div>
+                                <div class="col-md-3 col-xs-12">
+                                    <h4>Demo:</h4>
+                                    <input class="pull-right" type="text" name="datefilter" value="10/24/1984" />
+                                </div>
+                            </div>
+
+
+                        </div>
+
                         <script type="text/javascript">
                         $(function() {
 
-                            function cb(start, end) {
-                                $('#reportrange span').html(start.format('MMMM D, YYYY') + ' - ' + end.format('MMMM D, YYYY'));
-                            }
-                            cb(moment().subtract(29, 'days'), moment());
-
-                            $('#reportrange').daterangepicker({
-                                ranges: {
-                                   'Today': [moment(), moment()],
-                                   'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-                                   'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-                                   'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-                                   'This Month': [moment().startOf('month'), moment().endOf('month')],
-                                   'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+                            $('input[name="datefilter"]').daterangepicker({
+                                autoUpdateInput: false,
+                                locale: {
+                                    cancelLabel: 'clear'
                                 }
-                            }, cb);
+                            }, function(start, end) {
+                                $('input[name="datefilter"]').val(start.format('MM/DD/YYYY') + ' - ' + end.format('MM/DD/YYYY'));
+                            });
+
+                            $('input[name="datefilter"]').on('cancel.daterangepicker', function(ev, picker) {
+                                $('input[name="datefilter"]').val('');
+                            });
 
                         });
                         </script>
 
                     </div>
+
+
 
                     <div id="config" name="config">
 

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
         <title>Date Range Picker for Bootstrap</title>
         <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+        <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
         <script src="moment.min.js"></script>         
 
@@ -14,6 +14,12 @@
 
         <script src="website.js"></script>
         <link rel="stylesheet" type="text/css" href="website.css" />
+
+        <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+        <!--[if lt IE 9]>
+          <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+          <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+        <![endif]-->
 
         <meta name="google-site-verification" content="1fP-Eo9i1ozV4MUlqZv2vsLv1r7tvYutUb6i38v0_vg" />
     </head>


### PR DESCRIPTION
Apologies for previous pull request which was based on the master branch.

In this commit I add on focus event triggering of show(). When one adds e.g. `tabindex="0"` to the a `<div/>` one can focus on a `<div />` as well. When this `<div />` is the `<div />` the daterangepicker is attached to it makes sense to show the daterangepicker and improves keyboard navigate-ability.