### PR TITLE
Added dateCellClasses to customize classes for date cells

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -255,6 +255,10 @@
         if (typeof options.isInvalidDate === 'function')
             this.isInvalidDate = options.isInvalidDate;
 
+        if (typeof options.dateCellClasses === 'function' ||
+            $.isArray(options.dateCellClasses))
+            this.dateCellClasses = options.dateCellClasses;
+
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -810,6 +814,16 @@
                     //highlight dates in-between the selected dates
                     if (this.endDate != null && calendar[row][col] > this.startDate && calendar[row][col] < this.endDate)
                         classes.push('in-range');
+
+                    // Set custom classes configured
+                    var cellClasses;
+                    if (typeof this.dateCellClasses === 'function')
+                        cellClasses = this.dateCellClasses(calendar[row][col]);
+                    else 
+                        cellClasses = this.dateCellClasses;
+
+                    if ($.isArray(cellClasses))
+                        Array.prototype.push.apply(classes, cellClasses);
 
                     var cname = '', disabled = false;
                     for (var i = 0; i < classes.length; i++) {

--- a/website/index.html
+++ b/website/index.html
@@ -587,6 +587,9 @@
                                 that date should be available for selection or not.
                             </li>
                             <li>
+                                <code>dateCellClasses</code>: (function or array) If an array was specified, the classes will be added to every date cell. If a function was passed in, the function will be called with the date of the cell and the array returned from the function will be set to the date cell.
+                            </li>
+                            <li>
                                 <code>autoUpdateInput</code>: (boolean) Indicates whether the date range picker should
                                 automatically update the value of an <code>&lt;input&gt;</code> element it's attached to
                                 at initialization and when the selected dates change.


### PR DESCRIPTION
I added a new option 'dateCellClasses' to customize the classes for individual date cells.

If an array is passed in, it will add the classes in the array to every date cells.
If a function is passed in, the function will be passed the current date for the date cell and the returned array of classes will be set to the date cell.

The main use case is the function. It will allow us to style individual cells.