### PR TITLE
add option that lets you not synchronize times of start and end dates

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,5 +1,5 @@
 /**
-* @version: 2.1.13
+* @version: 2.1.14
 * @author: Dan Grossman http://www.dangrossman.info/
 * @copyright: Copyright (c) 2012-2015 Dan Grossman. All rights reserved.
 * @license: Licensed under the MIT license. See http://www.opensource.org/licenses/mit-license.php
@@ -53,6 +53,7 @@
         this.timePickerIncrement = 1;
         this.timePickerSeconds = false;
         this.linkedCalendars = true;
+        this.synchronizeTimes = false;
         this.autoUpdateInput = true;
         this.ranges = {};
 
@@ -242,6 +243,9 @@
 
         if (typeof options.timePicker24Hour === 'boolean')
             this.timePicker24Hour = options.timePicker24Hour;
+
+        if (typeof options.synchronizeTimes == 'boolean')
+            this.synchronizeTimes = options.synchronizeTimes;
 
         if (typeof options.autoApply === 'boolean')
             this.autoApply = options.autoApply;
@@ -1254,7 +1258,7 @@
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             //
 
-            if (this.endDate || date.isBefore(this.startDate)) {
+            if (!this.settingDateRange && (this.endDate || date.isBefore(this.startDate))) {
                 if (this.timePicker) {
                     var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
                     if (!this.timePicker24Hour) {
@@ -1268,7 +1272,10 @@
                     var second = this.timePickerSeconds ? parseInt(this.container.find('.left .secondselect').val(), 10) : 0;
                     date = date.clone().hour(hour).minute(minute).second(second);
                 }
-                this.endDate = null;
+                if (this.synchronizeTimes) {
+                  this.endDate = null;
+                }
+                this.settingDateRange = true;
                 this.setStartDate(date.clone());
             } else {
                 if (this.timePicker) {
@@ -1285,6 +1292,7 @@
                     date = date.clone().hour(hour).minute(minute).second(second);
                 }
                 this.setEndDate(date.clone());
+                this.settingDateRange = false;
                 if (this.autoApply)
                     this.clickApply();
             }

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dangrossman:bootstrap-daterangepicker',
-  version: '2.1.13',
+  version: '2.1.14',
   summary: 'Date range picker component for Bootstrap',
   git: 'https://github.com/dangrossman/bootstrap-daterangepicker',
   documentation: 'README.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-daterangepicker",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Date range picker component for Bootstrap",
   "main": "daterangepicker.js",
   "style": "daterangepicker.css",

--- a/website/index.html
+++ b/website/index.html
@@ -573,6 +573,9 @@
                                 <code>singleDatePicker</code>: (boolean) Show only a single calendar to choose one date, instead of a range picker with two calendars; the start and end dates provided to your callback will be the same single date chosen
                             </li>
                             <li>
+                                <code>synchronizeTimes</code>: (boolean) Set time of the end date to the same value as the start date
+                            </li>
+                            <li>
                                 <code>autoApply</code>: (boolean) Hide the apply and cancel buttons, and automatically apply a new date range as soon as two dates or a predefined range is selected
                             </li>
                             <li>


### PR DESCRIPTION
Currently when you start setting start time the hours/minutes component of the time of the end date are synchronized with the start date. 

This pull request adds an option not to automatically synchronize the time component.