### PR TITLE
provide default locale setting

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -68,7 +68,7 @@
         this.applyClass = 'btn-success';
         this.cancelClass = 'btn-default';
 
-        this.locale = {
+        this.locale = $.extend({
             format: 'MM/DD/YYYY',
             separator: ' - ',
             applyLabel: 'Apply',
@@ -78,7 +78,7 @@
             daysOfWeek: moment.weekdaysMin(),
             monthNames: moment.monthsShort(),
             firstDay: moment.localeData().firstDayOfWeek()
-        };
+        }, $.fn.daterangepicker.defaults.locale);
 
         this.callback = function() { };
 
@@ -1498,6 +1498,10 @@
             el.data('daterangepicker', new DateRangePicker(el, options, callback));
         });
         return this;
+    };
+
+    $.fn.daterangepicker.defaults = {
+
     };
     
     return DateRangePicker;


### PR DESCRIPTION
 Hi, I'm Chinese, please forgive my poor Enlish.

When I use daterangepicker in my project, I found that I must set locale every time. So I provide a way to set default locale just as jQuery. What needs to do is set $.fn.daterangepicker.defaults.locale one time.