### PR TITLE
Add option to show ISO week of the year

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -48,6 +48,7 @@
         this.singleDatePicker = false;
         this.showDropdowns = false;
         this.showWeekNumbers = false;
+        this.isoForWeekNumbers = false;
         this.timePicker = false;
         this.timePicker24Hour = false;
         this.timePickerIncrement = 1;
@@ -215,6 +216,9 @@
 
         if (typeof options.showWeekNumbers === 'boolean')
             this.showWeekNumbers = options.showWeekNumbers;
+
+        if (typeof options.isoForWeekNumbers === 'boolean')
+            this.isoForWeekNumbers = options.isoForWeekNumbers;
 
         if (typeof options.buttonClasses === 'string')
             this.buttonClasses = options.buttonClasses;
@@ -769,7 +773,7 @@
 
                 // add week number
                 if (this.showWeekNumbers)
-                    html += '<td class="week">' + calendar[row][0].week() + '</td>';
+                    html += '<td class="week">' + (this.isoForWeekNumbers ? calendar[row][0].isoWeek() : calendar[row][0].week()) + '</td>';
 
                 for (var col = 0; col < 7; col++) {
 


### PR DESCRIPTION
We're using ISO-based week numbers in our system which conflicts with locale-based week numbers used in datepicker. Here's what one can get having this handy option:

![image](https://cloud.githubusercontent.com/assets/35432/11838340/22e0d21e-a3ef-11e5-97bc-10fd523dc6d2.png)

Thank you for such a nice lib! The only missing piece are tests :(