### PR TITLE
Always show calendars when ranges are used

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -365,7 +365,11 @@
             }
         }
 
-        if (typeof options.ranges === 'undefined' && !this.singleDatePicker) {
+        if (options.alwaysShowCalendars) {
+            this.alwaysShowCalendars = true
+        }
+
+        if ((typeof options.ranges === 'undefined' || this.alwaysShowCalendars) && !this.singleDatePicker) {
             this.container.addClass('show-calendar');
         }
 
@@ -1185,7 +1189,10 @@
                     this.endDate.endOf('day');
                 }
 
-                this.hideCalendars();
+                if (!this.alwaysShowCalendars) {
+                    this.hideCalendars();
+                }
+
                 this.clickApply();
             }
         },

--- a/demo.html
+++ b/demo.html
@@ -118,6 +118,12 @@
 
               <div class="checkbox">
                 <label>
+                  <input type="checkbox" id="alwaysShowCalendars"> alwaysShowCalendars
+                </label>
+              </div>
+
+              <div class="checkbox">
+                <label>
                   <input type="checkbox" id="locale"> locale (with example settings)
                 </label>
               </div>
@@ -270,6 +276,9 @@
               'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
             };
           }
+
+          if ($('#alwaysShowCalendars').is(':checked'))
+            options.alwaysShowCalendars = true;
 
           if ($('#locale').is(':checked')) {
             options.locale = {


### PR DESCRIPTION
The default behaviour with ranges is to only show the predefined ranges and only show the calendar when custom range was selected.

We've started using this feature but want to always show the calendars, even for custom ranges. This option allows us to do that. Example in demo.html.

Default behaviour is maintained.