### PR TITLE
Add additional option for single date selection

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -46,6 +46,7 @@
         this.dateLimit = false;
         this.autoApply = false;
         this.singleDatePicker = false;
+        this.singleDate = false;
         this.showDropdowns = false;
         this.showWeekNumbers = false;
         this.timePicker = false;
@@ -229,6 +230,10 @@
             this.singleDatePicker = options.singleDatePicker;
             if (this.singleDatePicker)
                 this.endDate = this.startDate.clone();
+        }
+        
+        if (typeof options.singleDate === 'boolean') {
+            this.singleDate = options.singleDate;
         }
 
         if (typeof options.timePicker === 'boolean')
@@ -462,8 +467,14 @@
 
             if (!this.isShowing)
                 this.updateElement();
-
-            this.updateMonthsInView();
+                
+            if (this.singleDate) {
+                this.setEndDate(this.startDate);
+                this.updateMonthsInView();
+                this.hide();
+            } else {
+                this.updateMonthsInView();
+            }
         },
 
         setEndDate: function(endDate) {
@@ -492,7 +503,7 @@
 
             if (!this.isShowing)
                 this.updateElement();
-
+            
             this.updateMonthsInView();
         },
 


### PR DESCRIPTION
Firstly, many thanks for this brilliant plugin.

The team I'm working with have a requirement for selecting a single date when 2 pickers are visible – i.e. when singleDatePicker: false.

I'm proposing adding another option, e.g:
    
    singleDate: true 

which allows for the selection of a single date from multiple pickers. 

What this does is simply, upon date selection, sets the end date equal to the start date and hides the picker.

We would find this a very useful addition to this great plugin (this functionality is a requirement on a number of sites we're building). If there is anything else I need to do to get this implemented, please let me know.

Thanks again.