### PR TITLE
Add autoApplyRange and outsideClickCancels options

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -55,6 +55,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.autoApplyRange = true;
+        this.outsideClickCancels = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -252,6 +253,9 @@
 
         if (typeof options.autoApplyRange === 'boolean')
             this.autoApplyRange = options.autoApplyRange;
+
+        if (typeof options.outsideClickCancels === 'boolean')
+            this.outsideClickCancels = options.outsideClickCancels;
 
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
@@ -1143,7 +1147,11 @@
                 target.closest(this.container).length ||
                 target.closest('.calendar-table').length
                 ) return;
-            this.hide();
+            if (this.outsideClickCancels) {
+                this.clickCancel();
+            } else {
+                this.hide();
+            }
         },
 
         showCalendars: function() {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -54,6 +54,7 @@
         this.timePickerSeconds = false;
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
+        this.autoApplyRange = true;
         this.ranges = {};
 
         this.opens = 'right';
@@ -248,6 +249,9 @@
 
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
+
+        if (typeof options.autoApplyRange === 'boolean')
+            this.autoApplyRange = options.autoApplyRange;
 
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
@@ -1186,7 +1190,11 @@
                 }
 
                 this.hideCalendars();
-                this.clickApply();
+                if (this.autoApplyRange) {
+                    this.clickApply();
+                } else {
+                    this.updateView();
+                }
             }
         },
 


### PR DESCRIPTION
Hi, I added this two options to the plugin and I thought they may be useful for others.

The first option is to configure the behavior when clicking a range (auto-apply when clicking a range or not). The second option is to make the outside click behave like a cancel.

The defaults for both options are set to behave in a backward-compatible way.

Cheers.