### PR TITLE
make package.json and bower.json agree on jquery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/dangrossman/bootstrap-daterangepicker",
   "dependencies": {
-    "jquery": "^1.10",
+    "jquery": ">=1.10",
     "moment": "^2.9.0"
   }
 }


### PR DESCRIPTION
Using a caret version in package.json only allows minor, and patch updates. https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4