### PR TITLE
Add method `updateMomentLocale` to translate calendar view

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1507,6 +1507,20 @@
             this.container.remove();
             this.element.off('.daterangepicker');
             this.element.removeData();
+        },
+
+        updateMomentLocale: function(key) {
+          moment.locale(key);
+          this.locale.daysOfWeek = moment.weekdaysMin();
+          this.locale.monthNames = moment.monthsShort();
+          this.locale.firstDay = moment.localeData().firstDayOfWeek;
+          for (var attr in this) {
+            if (this[attr] && this[attr] instanceof moment().constructor) {
+              this[attr].locale(key);
+            }
+          }
+          this.updateView();
+          this.updateElement();
         }
 
     };


### PR DESCRIPTION
I have added method called `updateMomentLocale` to translate calendar view to the given moment locale key

```javascript
// The usage from the demo would be
$('#config-demo').data('daterangepicker').updateMomentLocale('fr')
```

I have tested and the demo page and it worked fine for me. If you thing it would be good to provide this feature, I will add an example on the `demo.html` page.