### PR TITLE
Use strict validation on formInputsChanged

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1446,9 +1446,9 @@
                 this.setEndDate(end);
 
                 if (isRight) {
-                    this.container.find('input[name="daterangepicker_start"]').val(this.startDate.format(this.locale.format));
-                } else {
                     this.container.find('input[name="daterangepicker_end"]').val(this.endDate.format(this.locale.format));
+                } else {
+                    this.container.find('input[name="daterangepicker_start"]').val(this.startDate.format(this.locale.format));
                 }
 
             }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1434,8 +1434,8 @@
 
         formInputsChanged: function(e) {
             var isRight = $(e.target).closest('.calendar').hasClass('right');
-            var start = moment(this.container.find('input[name="daterangepicker_start"]').val(), this.locale.format);
-            var end = moment(this.container.find('input[name="daterangepicker_end"]').val(), this.locale.format);
+            var start = moment(this.container.find('input[name="daterangepicker_start"]').val(), this.locale.format, true);
+            var end = moment(this.container.find('input[name="daterangepicker_end"]').val(), this.locale.format, true);
 
             if (start.isValid() && end.isValid()) {
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1452,6 +1452,12 @@
                 }
 
             }
+            else if (!start.isValid()) {
+                this.container.find('input[name="daterangepicker_start"]').val(this.oldStartDate.format(this.locale.format));
+            }
+            else if (!end.isValid()) {
+                this.container.find('input[name="daterangepicker_end"]').val(this.oldEndDate.format(this.locale.format));
+            }
 
             this.updateCalendars();
             if (this.timePicker) {


### PR DESCRIPTION
Don't use the permissive `moment(date, format).isValid()` function, use `moment(date, format, true).isValid()` instead. 

This won't allow manually adding inputs like `1/1/2016` when using the expanded form like `Fri, Jan 1 2016`. This way the plugin will become less error prone.

When an input is invalid we revert back to the previous input value.