### PR TITLE
Manage custom ranges labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 *.sublime-workspace
 *.sublime-project
+.idea

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,5 +1,5 @@
 /**
-* @version: 2.1.17
+* @version: 2.1.18
 * @author: Dan Grossman http://www.dangrossman.info/
 * @copyright: Copyright (c) 2012-2015 Dan Grossman. All rights reserved.
 * @license: Licensed under the MIT license. See http://www.opensource.org/licenses/mit-license.php
@@ -163,7 +163,10 @@
 
             if (typeof options.locale.customRangeLabel === 'string')
               this.locale.customRangeLabel = options.locale.customRangeLabel;
+        }
 
+        if (typeof options.rangesLabels === 'object') {
+            this.locale = $.extend(this.locale, options.rangesLabels);
         }
 
         if (typeof options.startDate === 'string')
@@ -317,6 +320,9 @@
                 if ((this.minDate && end.isBefore(this.minDate)) || (maxDate && start.isAfter(maxDate)))
                     continue;
                 
+                if(typeof this.locale[range] === 'string')
+                    range = this.locale[range];
+
                 //Support unicode chars in the range names.
                 var elem = document.createElement('textarea');
                 elem.innerHTML = range;


### PR DESCRIPTION
This change allow custom ranges labels in datepicker. You can setup this label introducing a new configuration **rangesLabels**. E.g.

```json
rangesLabels: {
    lastMonths: moment().subtract(1, 'month').format('MMMM'),
    last2Months: moment().subtract(2, 'month').format('MMMM'),
    last3Months: moment().subtract(4, 'month').format('MMM') + ' - ' + moment().subtract(1, 'month').format('MMM'),
    last6Months: moment().subtract(7, 'month').format('MMM') + ' - ' + moment().subtract(1, 'month').format('MMM'),
    lastYear: moment().subtract(1, 'year').format('YYYY')
},
ranges: {
    lastMonths: [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
    last2Months: [moment().subtract(2, 'month').startOf('month'), moment().subtract(2, 'month').endOf('month')],
    last3Months: [moment().subtract(4, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
    last6Months: [moment().subtract(7, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
    lastYear: [moment().subtract(1, 'year').month(0).startOf('month'), moment().subtract(1, 'year').month(11).endOf('month')]
}
```

This show:

- January
- December
- Oct - Jan
- Jul to Jan
- 2015