### PR TITLE
Added boolean "showWithRanges" option for show always picker with ranges

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -335,6 +335,9 @@
             }
             if(this.showWithRanges === false)
               list += '<li>' + this.locale.customRangeLabel + '</li>';
+            else
+              list += '<li style="display: none;">' + this.locale.customRangeLabel + '</li>';
+            
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
         }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -54,6 +54,7 @@
         this.timePickerSeconds = false;
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
+        this.showWithRanges = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -249,6 +250,9 @@
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
 
+        if (typeof options.showWithRanges === 'boolean')
+            this.showWithRanges = options.showWithRanges;
+
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
 
@@ -329,7 +333,8 @@
             for (range in this.ranges) {
                 list += '<li>' + range + '</li>';
             }
-            list += '<li>' + this.locale.customRangeLabel + '</li>';
+            if(this.showWithRanges === false)
+              list += '<li>' + this.locale.customRangeLabel + '</li>';
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
         }
@@ -365,7 +370,7 @@
             }
         }
 
-        if (typeof options.ranges === 'undefined' && !this.singleDatePicker) {
+        if ((typeof options.ranges === 'undefined' && !this.singleDatePicker) || this.showWithRanges) {
             this.container.addClass('show-calendar');
         }
 
@@ -1185,7 +1190,9 @@
                     this.endDate.endOf('day');
                 }
 
-                this.hideCalendars();
+                if(!this.showWithRanges) {
+                  this.hideCalendars();
+                }
                 this.clickApply();
             }
         },


### PR DESCRIPTION
When ranges{} object is defined picker not shown, because show-calendar class is removed, and when selecting a range picker are hide. This is not usual for people and for avoid this i add "showWithRanges" that are default false, but if setted to true avoid the hideCalendars() on clickRange()