### PR TITLE
Fire hide event after view gets updated

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1281,6 +1281,8 @@
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             //
 
+            var needApplying = false;
+
             if (this.endDate || date.isBefore(this.startDate, 'day')) {
                 if (this.timePicker) {
                     var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
@@ -1317,16 +1319,19 @@
                 }
                 this.setEndDate(date.clone());
                 if (this.autoApply)
-                    this.clickApply();
+                    needApplying = true;
             }
 
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
                 if (!this.timePicker)
-                    this.clickApply();
+                    needApplying = true;
             }
 
             this.updateView();
+
+            if (needApplying)
+                this.clickApply();
 
         },
 


### PR DESCRIPTION
I have an method bound with `hide.daterangepicker` event but I have to read the content in the view on my methods. I found out that `hide.daterangepicker` is not getting the latest view. This PR is to move `apply` and `hide` events to fire after the view get updated. I thinks it make mode sense this way.