### PR TITLE
Fire hide event after cancel and apply

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1331,15 +1331,15 @@
         },
 
         clickApply: function(e) {
-            this.hide();
             this.element.trigger('apply.daterangepicker', this);
+            this.hide();
         },
 
         clickCancel: function(e) {
             this.startDate = this.oldStartDate;
             this.endDate = this.oldEndDate;
-            this.hide();
             this.element.trigger('cancel.daterangepicker', this);
+            this.hide();
         },
 
         monthOrYearChanged: function(e) {


### PR DESCRIPTION
This is related to https://github.com/dangrossman/bootstrap-daterangepicker/pull/959.

It visually makes more sense to trigger `apply` and `cancel` events before `hide` as you really click apply/cancel before the calendar is hidden.