### PR TITLE
disableHoverDate

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -54,6 +54,7 @@
         this.timePickerSeconds = false;
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
+        this.disableHoverDate = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -255,6 +256,9 @@
         if (typeof options.isInvalidDate === 'function')
             this.isInvalidDate = options.isInvalidDate;
 
+        if (typeof options.disableHoverDate === 'boolean')
+            this.disableHoverDate = options.disableHoverDate;
+
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -316,7 +320,7 @@
                 // after the maximum, don't display this range option at all.
                 if ((this.minDate && end.isBefore(this.minDate)) || (maxDate && start.isAfter(maxDate)))
                     continue;
-                
+
                 //Support unicode chars in the range names.
                 var elem = document.createElement('textarea');
                 elem.innerHTML = range;
@@ -540,7 +544,7 @@
                 } else {
                     this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');
                 }
-                
+
             } else {
                 if (this.leftCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM') && this.rightCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM')) {
                     this.leftCalendar.month = this.startDate.clone().date(2);
@@ -1167,7 +1171,7 @@
                 this.container.find('input[name=daterangepicker_start]').val(dates[0].format(this.locale.format));
                 this.container.find('input[name=daterangepicker_end]').val(dates[1].format(this.locale.format));
             }
-            
+
         },
 
         clickRange: function(e) {
@@ -1215,6 +1219,9 @@
         },
 
         hoverDate: function(e) {
+
+        	if (this.disableHoverDate)
+        		return;
 
             //ignore mouse movements while an above-calendar text input has focus
             if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
@@ -1298,7 +1305,7 @@
                 this.endDate = null;
                 this.setStartDate(date.clone());
             } else if (!this.endDate && date.isBefore(this.startDate)) {
-                //special case: clicking the same date for start/end, 
+                //special case: clicking the same date for start/end,
                 //but the time of the end date is before the start date
                 this.setEndDate(this.startDate.clone());
             } else {
@@ -1520,7 +1527,7 @@
         });
         return this;
     };
-    
+
     return DateRangePicker;
 
 }));

--- a/demo.html
+++ b/demo.html
@@ -23,7 +23,7 @@
         <h1 style="margin: 0 0 20px 0">Configuration Builder</h1>
 
         <div class="well configurator">
-           
+
           <form>
           <div class="row">
 
@@ -132,6 +132,9 @@
                 <label>
                   <input type="checkbox" id="autoUpdateInput" checked="checked"> autoUpdateInput
                 </label>
+                <label>
+                  <input type="checkbox" id="disableHoverDate" checked="checked"> disableHoverDate
+                </label>
               </div>
 
             </div>
@@ -209,7 +212,7 @@
         $('#config-text').keyup(function() {
           eval($(this).val());
         });
-        
+
         $('.configurator input, .configurator select').change(function() {
           updateConfig();
         });
@@ -235,7 +238,7 @@
 
           if ($('#singleDatePicker').is(':checked'))
             options.singleDatePicker = true;
-          
+
           if ($('#showDropdowns').is(':checked'))
             options.showDropdowns = true;
 
@@ -244,7 +247,7 @@
 
           if ($('#timePicker').is(':checked'))
             options.timePicker = true;
-          
+
           if ($('#timePicker24Hour').is(':checked'))
             options.timePicker24Hour = true;
 
@@ -253,7 +256,7 @@
 
           if ($('#timePickerSeconds').is(':checked'))
             options.timePickerSeconds = true;
-          
+
           if ($('#autoApply').is(':checked'))
             options.autoApply = true;
 
@@ -292,15 +295,19 @@
           if (!$('#autoUpdateInput').is(':checked'))
             options.autoUpdateInput = false;
 
+          if (!$('#disableHoverDate').is(':checked'))
+            options.disableHoverDate = false;
+
+
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();
 
-          if ($('#startDate').val().length) 
+          if ($('#startDate').val().length)
             options.startDate = $('#startDate').val();
 
           if ($('#endDate').val().length)
             options.endDate = $('#endDate').val();
-          
+
           if ($('#minDate').val().length)
             options.minDate = $('#minDate').val();
 
@@ -325,7 +332,7 @@
           $('#config-text').val("$('#demo').daterangepicker(" + JSON.stringify(options, null, '    ') + ", function(start, end, label) {\n  console.log(\"New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')\");\n});");
 
           $('#config-demo').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); });
-          
+
         }
 
       });

--- a/website/index.html
+++ b/website/index.html
@@ -7,7 +7,7 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
         <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
-        <script src="moment.min.js"></script>         
+        <script src="moment.min.js"></script>
 
         <script src="daterangepicker.js"></script>
         <link rel="stylesheet" type="text/css" href="daterangepicker.css" />
@@ -86,7 +86,7 @@
 
                         <h1 style="margin: 0 0 20px 0">Date Range Picker</h1>
                         <p style="font-size: 18px; margin-bottom: 0">
-                            A JavaScript component for choosing date ranges. 
+                            A JavaScript component for choosing date ranges.
                             <br />
                             Designed to work with the Bootstrap CSS framework.
                         </p>
@@ -161,7 +161,7 @@
                         </p>
 
                         <a style="display: block; height: 300px; background: url('drp.png') top right no-repeat; background-size: auto 100%; border: 1px solid #ccc; margin-bottom: 20px" href="https://awio.iljmp.com/5/drpdemo" title="Click for a Live Demo"></a>
-                    
+
                     </div>
 
                     <div id="usage" name="usage">
@@ -183,7 +183,7 @@
                         <hr />
 
                         <p>
-                            You can customize Date Range Picker with <a href="#options">options</a>, and 
+                            You can customize Date Range Picker with <a href="#options">options</a>, and
                             get notified when the user chooses new dates by providing a callback function.
                         </p>
 
@@ -281,7 +281,7 @@
                                 $('input[name="birthdate"]').daterangepicker({
                                     singleDatePicker: true,
                                     showDropdowns: true
-                                }, 
+                                },
                                 function(start, end, label) {
                                     var years = moment().diff(start, 'years');
                                     alert("You are " + years + " years old.");
@@ -342,9 +342,9 @@
                             <h3>Input Initially Empty</h3>
 
                             <p>
-                                If you're using a date range as a filter, you may want to attach a picker to an 
+                                If you're using a date range as a filter, you may want to attach a picker to an
                                 input but leave it empty by default. This example shows how to accomplish that
-                                using the <code>autoUpdateInput</code> setting, and the <code>apply</code> and 
+                                using the <code>autoUpdateInput</code> setting, and the <code>apply</code> and
                                 <code>cancel</code> events.
                             </p>
 
@@ -391,7 +391,7 @@
                         <h2>Configuration Generator</h2>
 
                         <div class="well configurator">
-                                           
+
                           <form>
                           <div class="row">
 
@@ -501,7 +501,11 @@
                                   <input type="checkbox" id="autoUpdateInput" checked="checked"> autoUpdateInput
                                 </label>
                               </div>
-
+															<div class="checkbox">
+                                <label>
+                                  <input type="checkbox" id="disableHoverDate" checked="checked"> disableHoverDate
+                                </label>
+                              </div>
                             </div>
                             <div class="col-md-4">
 
@@ -645,6 +649,10 @@
                                 automatically update the value of an <code>&lt;input&gt;</code> element it's attached to
                                 at initialization and when the selected dates change.
                             </li>
+                            <li>
+                                <code>disableHoverDate</code>: (boolean) Indicates whether hover the calendar should
+                                automatically change the displayed value of an <code>&lt;input&gt;</code> element.
+                            </li>
                         </ul>
 
                     </div>
@@ -656,14 +664,14 @@
                         <p>
                             You can programmatically update the <code>startDate</code> and <code>endDate</code>
                             in the picker using the <code>setStartDate</code> and <code>setEndDate</code> methods.
-                            You can access the Date Range Picker object and its functions and properties through 
+                            You can access the Date Range Picker object and its functions and properties through
                             data properties of the element you attached it to.
                         </p>
 
                         <script src="https://gist.github.com/dangrossman/8ff9b1220c9b5682e8bd.js"></script>
 
                         <br />
-                        
+
                         <ul class="nobullets">
                             <li>
                                 <code>setStartDate(Date/moment/string)</code>: Sets the date range picker's currently selected start date to the provided date
@@ -800,7 +808,7 @@
         <div id="footer">
             Copyright &copy; 2015 <a href="http://www.awio.com">Awio Web Services LLC</a>.
             &nbsp;
-            Developed and maintained by <a href="http://www.dangrossman.info/">Dan Grossman</a>. 
+            Developed and maintained by <a href="http://www.dangrossman.info/">Dan Grossman</a>.
             &nbsp;
         </div>
 

--- a/website/website.js
+++ b/website/website.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
     $('#config-text').keyup(function() {
       eval($(this).val());
     });
-    
+
     $('.configurator input, .configurator select').change(function() {
       updateConfig();
     });
@@ -29,7 +29,7 @@ $(document).ready(function() {
 
       if ($('#singleDatePicker').is(':checked'))
         options.singleDatePicker = true;
-      
+
       if ($('#showDropdowns').is(':checked'))
         options.showDropdowns = true;
 
@@ -38,7 +38,7 @@ $(document).ready(function() {
 
       if ($('#timePicker').is(':checked'))
         options.timePicker = true;
-      
+
       if ($('#timePicker24Hour').is(':checked'))
         options.timePicker24Hour = true;
 
@@ -47,7 +47,7 @@ $(document).ready(function() {
 
       if ($('#timePickerSeconds').is(':checked'))
         options.timePickerSeconds = true;
-      
+
       if ($('#autoApply').is(':checked'))
         options.autoApply = true;
 
@@ -86,15 +86,18 @@ $(document).ready(function() {
       if (!$('#autoUpdateInput').is(':checked'))
         options.autoUpdateInput = false;
 
+      if (!$('#disableHoverDate').is(':checked'))
+          options.disableHoverDate = false;
+
       if ($('#parentEl').val().length)
         options.parentEl = $('#parentEl').val();
 
-      if ($('#startDate').val().length) 
+      if ($('#startDate').val().length)
         options.startDate = $('#startDate').val();
 
       if ($('#endDate').val().length)
         options.endDate = $('#endDate').val();
-      
+
       if ($('#minDate').val().length)
         options.minDate = $('#minDate').val();
 
@@ -119,7 +122,7 @@ $(document).ready(function() {
       $('#config-text').val("$('#demo').daterangepicker(" + JSON.stringify(options, null, '    ') + ", function(start, end, label) {\n  console.log(\"New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')\");\n});");
 
       $('#config-demo').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); });
-      
+
     }
 
     if ($(window).width() > 980) {


### PR DESCRIPTION
The hoverDate function I found it confusing that the input field values are changing as I hover the calendar. Specially when changing hours.
So  I added a new option: "disableHoverDate", that indicates whether hover the calendar should automatically change the displayed value of an <code>&lt;input&gt;</code> element.