### PR TITLE
Add triggerElements options

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -39,6 +39,7 @@
         //default settings for options
         this.parentEl = 'body';
         this.element = $(element);
+        this.triggerElements = this.element;
         this.startDate = moment().startOf('day');
         this.endDate = moment().endOf('day');
         this.minDate = false;
@@ -130,6 +131,10 @@
 
         this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(options.template).appendTo(this.parentEl);
+
+        if (options.triggerElements && $(options.triggerElements).length) {
+            this.triggerElements = $(options.triggerElements);
+        }
 
         //
         // handle all the possible options overriding defaults
@@ -412,16 +417,18 @@
             .on('mouseenter.daterangepicker', 'li', $.proxy(this.hoverRange, this))
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
 
-        if (this.element.is('input')) {
-            this.element.on({
-                'click.daterangepicker': $.proxy(this.show, this),
-                'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.elementChanged, this),
-                'keydown.daterangepicker': $.proxy(this.keydown, this)
-            });
-        } else {
-            this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
-        }
+        this.triggerElements.each($.proxy(function(index, trigger) {
+            if (trigger === this.element.get(0) && this.element.is('input')) {
+                $(trigger).on({
+                    'click.daterangepicker': $.proxy(this.show, this),
+                    'focus.daterangepicker': $.proxy(this.show, this),
+                    'keyup.daterangepicker': $.proxy(this.elementChanged, this),
+                    'keydown.daterangepicker': $.proxy(this.keydown, this)
+                });
+            } else {
+                $(trigger).on('click.daterangepicker', $.proxy(this.toggle, this));
+            }
+        }, this));
 
         //
         // if attached to a text input, set the initial value
@@ -1135,7 +1142,7 @@
             if (
                 // ie modal dialog fix
                 e.type == "focusin" ||
-                target.closest(this.element).length ||
+                target.closest(this.triggerElements).length ||
                 target.closest(this.container).length ||
                 target.closest('.calendar-table').length
                 ) return;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -418,7 +418,7 @@
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
 
         this.triggerElements.each($.proxy(function(index, trigger) {
-            if (trigger === this.element.get(0) && this.element.is('input')) {
+            if (trigger === this.element.get(0) && this.element.is('input:enabled:not([readonly])')) {
                 $(trigger).on({
                     'click.daterangepicker': $.proxy(this.show, this),
                     'focus.daterangepicker': $.proxy(this.show, this),

--- a/demo.html
+++ b/demo.html
@@ -134,6 +134,11 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="triggerElements"> triggerElements (with icon inside the input)
+                </label>
+              </div>
             </div>
             <div class="col-md-4">
 
@@ -214,10 +219,6 @@
           updateConfig();
         });
 
-        $('.demo i').click(function() {
-          $(this).parent().find('input').click();
-        });
-
         $('#startDate').daterangepicker({
           singleDatePicker: true,
           startDate: moment().subtract(6, 'days')
@@ -232,6 +233,9 @@
 
         function updateConfig() {
           var options = {};
+
+          if ($('#triggerElements').is(':checked'))
+            options.triggerElements = '.demo input, .demo i';
 
           if ($('#singleDatePicker').is(':checked'))
             options.singleDatePicker = true;


### PR DESCRIPTION
I have added `triggerElements` option to used when you want to have other elements to open up/close the calendar. 

The use case is from the demo page where you want the icon to control the calendar. 

Originally you use extra JS to bind the click event as:
```
$('.demo i').click(function() {          
  $(this).parent().find('input').click();
});
```
But the problem is that it does not behave well with `outsideClick` method. So, if you click the icon while the calendar still opens it will flash out and reset the calendar. 

If you integrate with `triggerElements` option, it makes the interaction more smooth. 

You can try it out on the demo page as I have also updated it.