### PR TITLE
Make template options to be complied jquery object

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -96,7 +96,7 @@
         options = $.extend(this.element.data(), options);
 
         //html template for the picker UI
-        if (typeof options.template !== 'string')
+        if (typeof options.template !== 'string' && !(options.template instanceof jQuery))
             options.template = '<div class="daterangepicker dropdown-menu">' +
                 '<div class="calendar left">' +
                     '<div class="daterangepicker_input">' +


### PR DESCRIPTION
It is the fix from https://github.com/dangrossman/bootstrap-daterangepicker/pull/904
> I have used `daterangepicker` with the custom template that contain `angular` directive. To make angular binding in my template work, it has to be compiled (to be jQuery object) using `$compile` from angular as `{ template: $compile(templateSring)(scope) }`.
>
I created this PR as it might useful for those who using this `daterangepicker` with Angular app.