### PR TITLE
only weakly require twbs:bootstrap

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dangrossman:bootstrap-daterangepicker',
-  version: '2.1.18',
+  version: '2.1.19',
   summary: 'Date range picker component for Bootstrap',
   git: 'https://github.com/dangrossman/bootstrap-daterangepicker',
   documentation: 'README.md'
@@ -9,7 +9,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0.1');
 
-  api.use('twbs:bootstrap@3.3.4', ["client"]);
+  api.use('twbs:bootstrap@3.3.4', ["client"], {weak: true});
   api.use('momentjs:moment@2.10.3', ["client"]);
   api.use('jquery@1.11.3_2', ["client"]);
 


### PR DESCRIPTION
This allows apps that integrate bootstrap via a different package, for example nemo64:bootstrap, to not be forced to install twbs:bootstrap