### PR TITLE
Autoapply fix

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1174,7 +1174,9 @@
 
                 if (!this.alwaysShowCalendars)
                     this.hideCalendars();
-                this.clickApply();
+					
+				if (this.autoApply)
+					this.clickApply();
             }
         },
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1174,9 +1174,9 @@
 
                 if (!this.alwaysShowCalendars)
                     this.hideCalendars();
-					
-				if (this.autoApply)
-					this.clickApply();
+                    
+                if (this.autoApply)
+                    this.clickApply();
             }
         },
 


### PR DESCRIPTION
When autoApply is set to false, I would expect the behaviour to be consistent for all range selections. However it immediately hides the popup when you click on predefined date ranges. Now it will only close when you click the Apply button.