### PR TITLE
Add locale.weekLabel option to example

### DIFF
--- a/website/website.js
+++ b/website/website.js
@@ -77,6 +77,7 @@ $(document).ready(function() {
           fromLabel: 'From',
           toLabel: 'To',
           customRangeLabel: 'Custom',
+          weekLabel: 'W',
           daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
           monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
           firstDay: 1


### PR DESCRIPTION
All available locale options should probably be included in the example locale. Currently it seems to include all options except `weekLabel`.