### PR TITLE
Fix ranges option, hide calendar by default

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1342,7 +1342,9 @@
           }
           if (customRange) {
               this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
-              this.showCalendars();
+              if(this.alwaysShowCalendars){
+                this.showCalendars();
+              }
           }
         },
 


### PR DESCRIPTION
Show calendar on first click only when `alwaysShowCalendars` option is enabled.