### PR TITLE
fix sass style for calendar cells

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -90,7 +90,9 @@
     white-space: nowrap;
     cursor: pointer; }
     .daterangepicker td.available:hover, .daterangepicker th.available:hover {
-      background: #eee; }
+      background-color: #eee;
+      border-color: transparent;
+      color: inherit; }
     .daterangepicker td.week, .daterangepicker th.week {
       font-size: 80%;
       color: #ccc; }

--- a/daterangepicker.scss
+++ b/daterangepicker.scss
@@ -275,7 +275,9 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
 
     &.available {
       &:hover {
-        background: $daterangepicker-cell-hover-bg-color;
+        background-color: $daterangepicker-cell-hover-bg-color;
+        border-color: $daterangepicker-cell-hover-border-color;
+        color: $daterangepicker-cell-hover-color;
       }
     }
 


### PR DESCRIPTION
To customize the calendar cells' hover style, 3 SASS variables are defined:
```sass
$daterangepicker-cell-hover-color:           $daterangepicker-color !default;
$daterangepicker-cell-hover-border-color:    $daterangepicker-cell-border-color !default;
$daterangepicker-cell-hover-bg-color:        #eee !default;
```

However, only `$daterangepicker-cell-hover-bg-color` is being used in the stylesheet:

```sass
.#{$prefix-class} {
  /* [...] */
  td, th {
    /* [...] */
    &.available {
      &:hover {
        background: $daterangepicker-cell-hover-bg-color;
      }
    }
  }
}
```
---

This commit adds the `color` and `border-color` declarations. 
It also replace `background` property by `background-color`, as that's how it's done in similar parts of the stylesheet