### PR TITLE
Add functionality to add custom class to dates

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -57,6 +57,9 @@
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
         this.ranges = {};
+        //accepts array of 'special' dates that will be given 'specialClass' class
+        this.specialClass = 'special';
+        this.specialDates = [];
 
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
@@ -341,6 +344,14 @@
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
         }
+        
+        if(typeof options.specialClass == 'string') {
+            this.specialClass = options.specialClass;
+        }
+
+        if(typeof options.specialDates == 'object') {
+            this.specialDates = options.specialDates;
+        }
 
         if (typeof cb === 'function') {
             this.callback = cb;
@@ -506,6 +517,15 @@
 
         isInvalidDate: function() {
             return false;
+        },
+        
+        isSpecialDate: function(date) {
+            var special = false;
+            $.each(this.specialDates, function() {
+                if(date.isSame(this))
+                    special = true;
+            });
+            return special ? true : false;
         },
 
         updateView: function() {
@@ -783,6 +803,10 @@
                     //don't allow selection of dates after the maximum date
                     if (maxDate && calendar[row][col].isAfter(maxDate, 'day'))
                         classes.push('off', 'disabled');
+                        
+                    if (this.isSpecialDate(calendar[row][col])) {
+                        classes.push(this.specialClass);
+                    }    
 
                     //don't allow selection of date if a custom function decides it's invalid
                     if (this.isInvalidDate(calendar[row][col]))


### PR DESCRIPTION
Adding a couple of props (**specialDates** - array of moment dates, **specialClass** - class name to be appended) that will add a custom class to any dates specified in the **specialDates** array that is set in the options.

Can easily style them with the custom class that is chosen (falls back to 'special')