### PR TITLE
Fix end time getting reset to start time

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -853,7 +853,9 @@
                     }
 
                     if (selected.isBefore(this.startDate))
-                        selected = this.startDate.clone();
+                        selected = this.startDate.clone().startOf('day').add(moment.duration({'hour' : selected.hour(), 'minute': selected.minute(), 'second': selected.second()}));
+                        if(selected.isBefore(this.startDate))
+                            selected = selected.add(moment.duration({'day' : 1}));
 
                     if (maxDate && selected.isAfter(maxDate))
                         selected = maxDate.clone();


### PR DESCRIPTION
Fixes #943 by preserving the end time as it was before. Sets the end date to either the new start date or the day after the new start date if the end time is before the start time.