### PR TITLE
No endDate before startDate

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -790,7 +790,7 @@
                         classes.push('off');
 
                     //don't allow selection of dates before the minimum date
-                    if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day'))
+                    if ((this.minDate && calendar[row][col].isBefore(this.minDate, 'day')) || (!this.endDate && calendar[row][col].isBefore(this.startDate, 'day')))
                         classes.push('off', 'disabled');
 
                     //don't allow selection of dates after the maximum date


### PR DESCRIPTION
As the handling of left and right calendar was confusing our users, I tried to disable all the day's in the calendar's that are before the startDate, when it comes to the endDate selection.
Hopefully this is fine?