### PR TITLE
`autoRange` Feature.  Auto selects specified range

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -132,9 +132,6 @@
 
         if (typeof options.locale === 'object') {
 
-            if (typeof options.locale.autoRange === 'number')
-                this.locale.autoRange = options.locale.autoRange;
-
             if (typeof options.locale.direction === 'string')
                 this.locale.direction = options.locale.direction;
 
@@ -191,6 +188,9 @@
 
         if (typeof options.maxDate === 'object')
             this.maxDate = moment(options.maxDate);
+
+        if (typeof options.autoRange === 'number')
+            this.autoRange = options.autoRange;
 
         // sanity check for bad options
         if (this.minDate && this.startDate.isBefore(this.minDate))
@@ -1295,9 +1295,9 @@
             // * if autoapply is enabled, and an end date was chosen, apply the selection
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             // 
-            if (this.locale.autoRange){
+            if (this.autoRange){
                 var start_date = date;
-                var end_date = moment(date.format("YYYY-MM-DD")).add(6, 'day');
+                var end_date = moment(date.format("YYYY-MM-DD")).add(this.autoRange, 'day');
                 this.setStartDate(start_date.clone());
                 this.setEndDate(end_date.clone());
             } else {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -861,9 +861,15 @@
                 selected = this.endDate ? this.endDate.clone() : this.previousRightTime.clone();
                 minDate = this.startDate;
 
+                if (selected.isBefore(this.startDate))
+                    selected = this.startDate.clone();
+
+                if (maxDate && selected.isAfter(maxDate))
+                    selected = maxDate.clone();
+
                 //Preserve the time already selected
                 var timeSelector = this.container.find('.calendar.right .calendar-time div');
-                if (timeSelector.html() != '') {
+                if (!this.endDate && timeSelector.html() != '') {
 
                     selected.hour(timeSelector.find('.hourselect option:selected').val() || selected.hour());
                     selected.minute(timeSelector.find('.minuteselect option:selected').val() || selected.minute());

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -883,12 +883,6 @@
                             selected.hour(0);
                     }
 
-                    if (selected.isBefore(this.startDate))
-                        selected = this.startDate.clone();
-
-                    if (maxDate && selected.isAfter(maxDate))
-                        selected = maxDate.clone();
-
                 }
             }
 


### PR DESCRIPTION
Added `autoRange` option as a `number`.  If specified, it will ( on `clickDate` event) select the start_date and automatically select an end_date.  The end_date will be `autoRange` days ahead of the start_date.


Ex: User clicks on a date (2015-02-01) while the `autoRange` option is set to 7.  This will automatically select and highlight the daterange 2015-02-08).  Useful for daterangepickers that can only scope to specific date ranges.  i.e. 30 day span (month) or 7 day span (week).