### PR TITLE
Allowing other date formats and checking if date is valid

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -448,8 +448,15 @@
         constructor: DateRangePicker,
 
         setStartDate: function(startDate) {
-            if (typeof startDate === 'string')
-                this.startDate = moment(startDate, this.locale.format);
+            if (typeof startDate === 'string') {
+                var d = moment(startDate, this.locale.format);
+                if (!d.isValid()) {
+                    d = moment(startDate);
+                }
+                if (d.isValid()) {
+                    this.startDate = d;
+                }
+            }
 
             if (typeof startDate === 'object')
                 this.startDate = moment(startDate);
@@ -479,8 +486,15 @@
         },
 
         setEndDate: function(endDate) {
-            if (typeof endDate === 'string')
-                this.endDate = moment(endDate, this.locale.format);
+            if (typeof endDate === 'string') {
+                var d = moment(endDate, this.locale.format);
+                if (!d.isValid()) {
+                    d = moment(endDate);
+                }
+                if (d.isValid()) {
+                    this.endDate = d;
+                }
+            }
 
             if (typeof endDate === 'object')
                 this.endDate = moment(endDate);


### PR DESCRIPTION
This allows the user to set start and end dates as a string based either on the Americanized default locale that bootstrap-daterangepicker uses or on any of the formats that moment.js accepts. It also prevents an invalid moment.js object from being set to this.startDate and this.endDate.