### PR TITLE
autoUpdateInput currentdate

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1119,7 +1119,7 @@
             }
 
             //if a new date range was selected, invoke the user callback function
-            if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate))
+            if ((!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate)) || this.element.val() === '')
                 this.callback(this.startDate, this.endDate, this.chosenLabel);
 
             //if picker is attached to a text input, update it


### PR DESCRIPTION
This is a fix for single datepicker : 
if the autoUpdateInput is false, when you click on the current date the field won't update.