### PR TITLE
Add boolean option iniInputWithStartDate

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -31,6 +31,7 @@
         //default settings for options
         this.parentEl = 'body';
         this.element = $(element);
+        this.iniInputWithStartDate = true;
         this.startDate = moment().startOf('day');
         this.endDate = moment().endOf('day');
         this.minDate = false;
@@ -164,6 +165,9 @@
 
         }
         this.container.addClass(this.locale.direction);
+
+        if (typeof options.iniInputWithStartDate === 'boolean')
+            this.iniInputWithStartDate = options.iniInputWithStartDate;
 
         if (typeof options.startDate === 'string')
             this.startDate = moment(options.startDate, this.locale.format);
@@ -437,10 +441,14 @@
         //
 
         if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
-            this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            if (this.iniInputWithStartDate) {
+                this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            }
             this.element.trigger('change');
         } else if (this.element.is('input') && this.autoUpdateInput) {
-            this.element.val(this.startDate.format(this.locale.format));
+            if (this.iniInputWithStartDate) {
+                this.element.val(this.startDate.format(this.locale.format));
+            }
             this.element.trigger('change');
         }
 


### PR DESCRIPTION
iniInputWithStartDate is boolean option.
Its default value is true, just work like before.
The purpose of iniInputWithStartDate is 
If input is originally populated with date value, 
assign iniInputWithStartDate to false in order NOT to 
change(auto update) the input to StartDate when initialize