### PR TITLE
Added beforeDisplay callback for greater flexibility

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -77,6 +77,7 @@
         };
 
         this.callback = function() { };
+        this.beforeDisplay = function(self) { return true; };
 
         //some state information
         this.isShowing = false;
@@ -266,6 +267,9 @@
 
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
+            
+        if (typeof options.beforeDisplay === 'function')
+            this.beforeDisplay = options.beforeDisplay;
 
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
@@ -1092,6 +1096,8 @@
 
         show: function(e) {
             if (this.isShowing) return;
+
+            if (this.beforeDisplay(this) === false) { return; }
 
             // Create a click proxy that is private to this instance of datepicker, for unbinding
             this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);


### PR DESCRIPTION
I needed to set the dates from a custom chart component when the button was clicked, this seemed to be the best way and should allow complete flexibility. For example usage my callback looks like this:

    beforeDisplay: function(self) {
        if (chart.hasRange()) {
            self.setStartDate(moment.utc(chart.getStartTimeInMillis()));
            self.setEndDate(moment.utc(chart.getEndTimeInMillis()));
        }
    }

You can also stop the picker being displayed if the current state of your application means that a date range cannot be selected.