### PR TITLE
compactElementDisplay Option

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -49,6 +49,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.compactElementDisplay = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -267,6 +268,9 @@
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
 
+        if (typeof options.compactElementDisplay === 'boolean')
+            this.compactElementDisplay = options.compactElementDisplay;
+
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -289,7 +293,7 @@
                 if (split.length == 2) {
                     start = moment(split[0], this.locale.format);
                     end = moment(split[1], this.locale.format);
-                } else if (this.singleDatePicker && val !== "") {
+                } else if ((this.singleDatePicker || this.compactElementDisplay) && val !== "") {
                     start = moment(val, this.locale.format);
                     end = moment(val, this.locale.format);
                 }
@@ -443,7 +447,14 @@
         //
 
         if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
-            this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            var startString = this.startDate.format(this.locale.format);
+            var endString = this.endDate.format(this.locale.format)
+            if (this.compactElementDisplay && startString == endString) {
+                this.element.val(startString);
+            }
+            else {
+                this.element.val(startString + this.locale.separator + endString);
+            }
             this.element.trigger('change');
         } else if (this.element.is('input') && this.autoUpdateInput) {
             this.element.val(this.startDate.format(this.locale.format));
@@ -1566,7 +1577,7 @@
                 end = moment(dateString[1], this.locale.format);
             }
 
-            if (this.singleDatePicker || start === null || end === null) {
+            if (this.singleDatePicker || (dateString.length === 1 && this.compactElementDisplay) || start === null || end === null) {
                 start = moment(this.element.val(), this.locale.format);
                 end = start;
             }
@@ -1587,7 +1598,14 @@
 
         updateElement: function() {
             if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
-                this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+                var startString = this.startDate.format(this.locale.format);
+                var endString = this.endDate.format(this.locale.format);
+                if (this.compactElementDisplay && startString == endString) {
+                    this.element.val(startString);
+                }
+                else {
+                    this.element.val(startString + this.locale.separator + endString);
+                }
                 this.element.trigger('change');
             } else if (this.element.is('input') && this.autoUpdateInput) {
                 this.element.val(this.startDate.format(this.locale.format));

--- a/demo.html
+++ b/demo.html
@@ -137,6 +137,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="compactElementDisplay"> compactElementDisplay
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 
@@ -325,6 +331,9 @@
 
           if ($('#alwaysShowCalendars').is(':checked'))
             options.alwaysShowCalendars = true;
+
+          if ($('#compactElementDisplay').is(':checked'))
+            options.compactElementDisplay = true;
 
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();

--- a/example/amd/index.html
+++ b/example/amd/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="compactElementDisplay"> compactElementDisplay
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/amd/main.js
+++ b/example/amd/main.js
@@ -101,6 +101,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#compactElementDisplay').is(':checked'))
+      options.compactElementDisplay = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/example/browserify/index.html
+++ b/example/browserify/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="compactElementDisplay"> compactElementDisplay
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/browserify/main.js
+++ b/example/browserify/main.js
@@ -96,6 +96,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#compactElementDisplay').is(':checked'))
+      options.compactElementDisplay = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/website/index.html
+++ b/website/index.html
@@ -561,6 +561,12 @@
                                 </label>
                               </div>
 
+                              <div class="checkbox">
+                                <label>
+                                  <input type="checkbox" id="compactElementDisplay"> compactElementDisplay
+                                </label>
+                              </div>
+
                             </div>
 
                           </div>
@@ -688,6 +694,10 @@
                             </li>
                             <li>
                                 <code>parentEl</code>: (string) jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
+                            </li>
+                            <li>
+                                <code>compactElementDisplay</code>: (boolean) When the start and end of the selected range 
+								are the same, the HTML element will display a single string instead of a range.
                             </li>
                         </ul>
 

--- a/website/website.js
+++ b/website/website.js
@@ -96,6 +96,9 @@ $(document).ready(function() {
       if ($('#alwaysShowCalendars').is(':checked'))
         options.alwaysShowCalendars = true;
 
+      if ($('#compactElementDisplay').is(':checked'))
+        options.compactElementDisplay = true;
+
       if ($('#parentEl').val().length)
         options.parentEl = $('#parentEl').val();
 


### PR DESCRIPTION
Adds a `compactElementDisplay` option; when enabled, and when the start and end of the selected range are the same, it will cause the element to display as a single date (and/or time) string instead of a range. So you'd see something like `1/1/2000` instead of `1/1/2000 - 1/1/2000`.

This differs from `singleDatePicker` in that you're still able to select a multi-day range if you want to; it just eliminates the redundancy in the display if you happen to pick start==end.

It's just looking at the final formatted start/end strings and displaying one if they're the same, so it works with times as well, although admittedly not in any clever way.