### PR TITLE
Fix parent element. `parentEl` must be parent.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -29,8 +29,8 @@
     var DateRangePicker = function(element, options, cb) {
 
         //default settings for options
-        this.parentEl = 'body';
         this.element = $(element);
+        this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : this.element.parent();
         this.startDate = moment().startOf('day');
         this.endDate = moment().endOf('day');
         this.minDate = false;
@@ -124,7 +124,6 @@
                 '</div>' +
             '</div>';
 
-        this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(options.template).appendTo(this.parentEl);
 
         //


### PR DESCRIPTION
After obfuscation `this.parentEl` looses its real variable.
