### PR TITLE
Fix: the end of the range cannot before the start

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -325,9 +325,11 @@
                     end = maxDate.clone();
 
                 // If the end of the range is before the minimum or the start of the range is
-                // after the maximum, don't display this range option at all.
+                // after the maximum or the end of the range is before the start of the range,
+                // don't display this range option at all.
                 if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day')) 
-                  || (maxDate && start.isAfter(maxDate, this.timepicker ? 'minute' : 'day')))
+                  || (maxDate && start.isAfter(maxDate, this.timepicker ? 'minute' : 'day'))
+                  || (end.isBefore(start)))
                     continue;
 
                 //Support unicode chars in the range names.


### PR DESCRIPTION
If the end of the range is before the start of the range, should not display the range at all.
