### PR TITLE
Time is not being preserved when timepicker was enabled

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -873,7 +873,7 @@
 
                 //Preserve the time already selected
                 var timeSelector = this.container.find('.calendar.right .calendar-time div');
-                if (!this.endDate && timeSelector.html() != '') {
+                if (timeSelector.html() != '') {
 
                     selected.hour(timeSelector.find('.hourselect option:selected').val() || selected.hour());
                     selected.minute(timeSelector.find('.minuteselect option:selected').val() || selected.minute());


### PR DESCRIPTION


the `!this.endDate` was causing the date picker with `timePicker` and `timePicker24Hour` parameters to reset the hour time dropdown to `0`.
You can reproduce it in the demo page as well.

I believe this bug was introduced in the latest release and previous versions didn't have this issue, please consider high priority for this issue.

@dangrossman can you verify please?
![datepicker](https://cloud.githubusercontent.com/assets/402815/20404369/852f2c62-acb9-11e6-99e3-f4384d7c3c20.gif)


