### PR TITLE
Change "background" to "background-color" to preserve Bootstrap "background-clip"

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -1,7 +1,7 @@
 .daterangepicker {
   position: absolute;
   color: inherit;
-  background: #fff;
+  background-color: #fff;
   border-radius: 4px;
   width: 278px;
   padding: 4px;
@@ -77,7 +77,7 @@
     border: 1px solid #fff;
     padding: 4px;
     border-radius: 4px;
-    background: #fff; }
+    background-color: #fff; }
   .daterangepicker table {
     width: 100%;
     margin: 0; }
@@ -183,7 +183,7 @@
     width: 100%; }
   .ranges li {
     font-size: 13px;
-    background: #f5f5f5;
+    background-color: #f5f5f5;
     border: 1px solid #f5f5f5;
     border-radius: 4px;
     color: #08c;
@@ -191,11 +191,11 @@
     margin-bottom: 8px;
     cursor: pointer; }
     .ranges li:hover {
-      background: #08c;
+      background-color: #08c;
       border: 1px solid #08c;
       color: #fff; }
     .ranges li.active {
-      background: #08c;
+      background-color: #08c;
       border: 1px solid #08c;
       color: #fff; }
 

--- a/daterangepicker.scss
+++ b/daterangepicker.scss
@@ -116,7 +116,7 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
 .#{$prefix-class} {
   position: absolute;
   color: $daterangepicker-color;
-  background: $daterangepicker-bg-color;
+  background-color: $daterangepicker-bg-color;
   border-radius: $daterangepicker-border-radius;
   width: $daterangepicker-width;
   padding: $daterangepicker-padding;
@@ -256,7 +256,7 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
     border: $daterangepicker-calendar-border-size solid $daterangepicker-calendar-border-color;
     padding: $daterangepicker-calendar-margin;
     border-radius: $daterangepicker-calendar-border-radius;
-    background: $daterangepicker-calendar-bg-color;
+    background-color: $daterangepicker-calendar-bg-color;
   }
 
   table {
@@ -452,7 +452,7 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
 
   li {
     font-size: 13px;
-    background: $daterangepicker-ranges-bg-color;
+    background-color: $daterangepicker-ranges-bg-color;
     border: $daterangepicker-ranges-border-size solid $daterangepicker-ranges-border-color;
     border-radius: $daterangepicker-ranges-border-radius;
     color: $daterangepicker-ranges-color;
@@ -461,13 +461,13 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
     cursor: pointer;
 
     &:hover {
-      background: $daterangepicker-ranges-hover-bg-color;
+      background-color: $daterangepicker-ranges-hover-bg-color;
       border: $daterangepicker-ranges-hover-border-size solid $daterangepicker-ranges-hover-border-color;
       color: $daterangepicker-ranges-hover-color;
     }
 
     &.active {
-      background: $daterangepicker-ranges-hover-bg-color;
+      background-color: $daterangepicker-ranges-hover-bg-color;
       border: $daterangepicker-ranges-hover-border-size solid $daterangepicker-ranges-hover-border-color;
       color: $daterangepicker-ranges-hover-color;
     }


### PR DESCRIPTION
Using "background" CSS property overrides Bootstrap styling, specifically the "background-clip: padding-box". This PR fixes that.