### PR TITLE
Added window as alternative to currently-scoped instance of window

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -25,7 +25,7 @@
         // Browser globals
         root.daterangepicker = factory(root.moment, root.jQuery);
     }
-}(this, function(moment, $) {
+}(this || window, function(moment, $) {
     var DateRangePicker = function(element, options, cb) {
 
         //default settings for options


### PR DESCRIPTION
This slight addition is meant for solutions that do not create an instance of the window object.  When imported within a client-side .js file (e.g. during file bundling), the "this" variable that is passed into the IIF (line 28 of daterangepicker.js) is an empty object.  As I understand it, "this" should be a separate instance of window when daterangepicker.js is sourced from within an html file.

My apologies if there isn't something I have correctly understood.