### PR TITLE
Adding support for unicode characters in the customrangelabel

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -343,6 +343,11 @@
                 list += '<li data-range-key="' + range + '">' + range + '</li>';
             }
             if (this.showCustomRangeLabel) {
+                //Support unicode chars in the custom range name.
+                var elem = document.createElement('textarea');
+                elem.innerHTML = this.locale.customRangeLabel;
+                var rangeHtml = elem.value;
+                this.locale.customRangeLabel = rangeHtml;
                 list += '<li data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             }
             list += '</ul>';

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -160,9 +160,13 @@
             if (typeof options.locale.weekLabel === 'string')
               this.locale.weekLabel = options.locale.weekLabel;
 
-            if (typeof options.locale.customRangeLabel === 'string')
-              this.locale.customRangeLabel = options.locale.customRangeLabel;
-
+            if (typeof options.locale.customRangeLabel === 'string'){
+                //Support unicode chars in the custom range name.
+                var elem = document.createElement('textarea');
+                elem.innerHTML = options.locale.customRangeLabel;
+                var rangeHtml = elem.value;
+                this.locale.customRangeLabel = rangeHtml;
+            }
         }
         this.container.addClass(this.locale.direction);
 
@@ -342,12 +346,7 @@
             for (range in this.ranges) {
                 list += '<li data-range-key="' + range + '">' + range + '</li>';
             }
-            if (this.showCustomRangeLabel) {
-                //Support unicode chars in the custom range name.
-                var elem = document.createElement('textarea');
-                elem.innerHTML = this.locale.customRangeLabel;
-                var rangeHtml = elem.value;
-                this.locale.customRangeLabel = rangeHtml;
+            if (this.showCustomRangeLabel) {                
                 list += '<li data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             }
             list += '</ul>';

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -346,7 +346,7 @@
             for (range in this.ranges) {
                 list += '<li data-range-key="' + range + '">' + range + '</li>';
             }
-            if (this.showCustomRangeLabel) {                
+            if (this.showCustomRangeLabel) {
                 list += '<li data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             }
             list += '</ul>';


### PR DESCRIPTION
I had a problem when using danish characters in the custom range label that the match 

label == this.locale.customRangeLabel

in the hoverRange event caused the error 

Uncaught TypeError: Cannot read property '0' of undefined
    at DateRangePicker.hoverRange (daterangepicker.js:1140)

The line var label = e.target.getAttribute('data-range-key'); gave "Vælg interval", whereas this.locale.customRangeLabel has the value "V&#230;lg interval". 

I've solved it by using the same approach as for allowing unicode characters in the labels of the fixed intervals.