### PR TITLE
remove restriction to type of input for setting the initial value

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -280,7 +280,7 @@
 
         //if no start/end dates set, check if an input element contains initial values
         if (typeof options.startDate === 'undefined' && typeof options.endDate === 'undefined') {
-            if ($(this.element).is('input[type=text]')) {
+            if ($(this.element).is('input')) {
                 var val = $(this.element).val(),
                     split = val.split(this.locale.separator);
 


### PR DESCRIPTION
I use MVC Razor engine to generate my html and Datetime field input is of type datetime. I was wondering that daterangepicker can handle this kind of input if I set up the value as expected.
I modify just one line to remove the restriction of having a input of type text.
Only check if the element is an input element