### PR TITLE
Add hidden class to days that are outside of the current month

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -115,6 +115,8 @@
     background-color: #357ebd;
     border-color: transparent;
     color: #fff; }
+  .daterangepicker td.hidden {
+    visibility: hidden; }
   .daterangepicker th.month {
     width: auto; }
   .daterangepicker td.disabled, .daterangepicker option.disabled {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -796,7 +796,7 @@
 
                     //grey out the dates in other months displayed at beginning and end of this calendar
                     if (calendar[row][col].month() != calendar[1][1].month())
-                        classes.push('off');
+                        classes.push('off', 'hidden');
 
                     //don't allow selection of dates before the minimum date
                     if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day'))

--- a/daterangepicker.scss
+++ b/daterangepicker.scss
@@ -326,6 +326,10 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
         color: $daterangepicker-active-color;
       }
     }
+
+    &.hidden {
+      visibility: hidden;
+    }
   }
 
   th {


### PR DESCRIPTION
While editing the css to customize the datepicker, I see that, while hovering, the the days of other months in the current calendar can't get their css overriden without overriding the ones from the next or previous months that are also disabled. This change should allow the current user to update the css of those specific days without overriding all the disabled days of the pre/next calendar days.