### PR TITLE
Option added to define a custom icon system

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -29,7 +29,7 @@
     var DateRangePicker = function(element, options, cb) {
 
         //default settings for options
-        this.iconSystem = 'glyphicon';
+        this.iconSystem = ['fa', 'glyphicon'];
         this.parentEl = 'body';
         this.element = $(element);
         this.startDate = moment().startOf('day');
@@ -92,8 +92,11 @@
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
 
-        if (typeof options.iconSystem === 'string')
+        if (typeof options.iconSystem === 'string' ) {
+            this.iconSystem = [options.iconSystem];
+        } else if ( Array.isArray(options.iconSystem) ) {
             this.iconSystem = options.iconSystem;
+        }
         
         //html template for the picker UI
         if (typeof options.template !== 'string' && !(options.template instanceof $))
@@ -101,10 +104,10 @@
                 '<div class="calendar left">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini form-control" type="text" name="daterangepicker_start" value="" />' +
-                      '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-calendar"></i>' +
+                      '<i class="' + this.createIconClass('calendar') + '"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
-                        '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-time"></i>' +
+                        '<i class="' + this.createIconClass('time') + '"></i>' +
                       '</div>' +
                     '</div>' +
                     '<div class="calendar-table"></div>' +
@@ -112,10 +115,10 @@
                 '<div class="calendar right">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini form-control" type="text" name="daterangepicker_end" value="" />' +
-                      '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-calendar"></i>' +
+                      '<i class="' + this.createIconClass('calendar') + '"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
-                        '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-time"></i>' +
+                        '<i class="' + this.createIconClass('time') + '"></i>' +
                       '</div>' +
                     '</div>' +
                     '<div class="calendar-table"></div>' +
@@ -710,7 +713,7 @@
                 html += '<th></th>';
 
             if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
-                html += '<th class="prev available"><i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-' + arrow.left + '"></i></th>';
+                html += '<th class="prev available"><i class="'+ this.createIconClass(arrow.left) + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -752,7 +755,7 @@
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
-            	html += '<th class="next available"><i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-' + arrow.right + '"></i></th>';
+            	html += '<th class="next available"><i class="'+ this.createIconClass(arrow.right) + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -1611,8 +1614,20 @@
             this.container.remove();
             this.element.off('.daterangepicker');
             this.element.removeData();
-        }
+        },
 
+        createIconClass: function(icon) {
+            if ( icon )
+            {
+                return this.iconSystem.map(function(system){
+                    return system+' '+system+'-'+icon;
+                }).join(' ');
+            }
+            else
+            {
+                return this.iconSystem.join(' ');
+            }
+        }
     };
 
     $.fn.daterangepicker = function(options, callback) {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -29,6 +29,7 @@
     var DateRangePicker = function(element, options, cb) {
 
         //default settings for options
+        this.iconSystem = 'glyphicon';
         this.parentEl = 'body';
         this.element = $(element);
         this.startDate = moment().startOf('day');
@@ -91,16 +92,19 @@
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
 
+        if (typeof options.iconSystem === 'string')
+            this.iconSystem = options.iconSystem;
+        
         //html template for the picker UI
         if (typeof options.template !== 'string' && !(options.template instanceof $))
             options.template = '<div class="daterangepicker dropdown-menu">' +
                 '<div class="calendar left">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini form-control" type="text" name="daterangepicker_start" value="" />' +
-                      '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
+                      '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-calendar"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
-                        '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
+                        '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-time"></i>' +
                       '</div>' +
                     '</div>' +
                     '<div class="calendar-table"></div>' +
@@ -108,10 +112,10 @@
                 '<div class="calendar right">' +
                     '<div class="daterangepicker_input">' +
                       '<input class="input-mini form-control" type="text" name="daterangepicker_end" value="" />' +
-                      '<i class="fa fa-calendar glyphicon glyphicon-calendar"></i>' +
+                      '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-calendar"></i>' +
                       '<div class="calendar-time">' +
                         '<div></div>' +
-                        '<i class="fa fa-clock-o glyphicon glyphicon-time"></i>' +
+                        '<i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-time"></i>' +
                       '</div>' +
                     '</div>' +
                     '<div class="calendar-table"></div>' +
@@ -706,7 +710,7 @@
                 html += '<th></th>';
 
             if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
-                html += '<th class="prev available"><i class="fa fa-' + arrow.left + ' glyphicon glyphicon-' + arrow.left + '"></i></th>';
+                html += '<th class="prev available"><i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-' + arrow.left + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -748,7 +752,7 @@
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
-                html += '<th class="next available"><i class="fa fa-' + arrow.right + ' glyphicon glyphicon-' + arrow.right + '"></i></th>';
+            	html += '<th class="next available"><i class="'+ (this.iconSystem) +' '+ (this.iconSystem) +'-' + arrow.right + '"></i></th>';
             } else {
                 html += '<th></th>';
             }

--- a/website/index.html
+++ b/website/index.html
@@ -689,6 +689,9 @@
                             <li>
                                 <code>parentEl</code>: (string) jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
                             </li>
+                            <li>
+                                <code>iconSystem</code>: (string) Name and prefix to use for the classes of icon elements, if not provided this will be 'glyphicon'
+                            </li>
                         </ul>
 
                     </div>

--- a/website/index.html
+++ b/website/index.html
@@ -690,7 +690,7 @@
                                 <code>parentEl</code>: (string) jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
                             </li>
                             <li>
-                                <code>iconSystem</code>: (string) Name and prefix to use for the classes of icon elements, if not provided this will be 'glyphicon'
+                                <code>iconSystem</code>: (string or array) Name and prefix to use for the classes of icon elements, if not provided this will be ['fa', 'glyphicon'].
                             </li>
                         </ul>
 


### PR DESCRIPTION
Hi,

i had the need to modify the library because the project i working on uses a different icon system.

The implementation now provides the option to use a own icon system instead of the required Font Awesome and/or Glyphicon. This was not possible before, except maybe with Mutual Observers, due the hardcoded CSS definitions and recreation of the whole calendar HTML structure after each paging.

The icon system option accepts a string or array to support one ore multiple icon systems – like the existing implementation does it hardcoded with Font Awesome and Glyphicon. A new prototype function in Daterangepicker, named createIconClass, does the prefixing and joining of icon classes.

Please review my changed and i would appreciate it if they get merged into the main repo.

Thank you already
Robert