### PR TITLE
Do not update range on hover.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1260,12 +1260,6 @@
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
 
-            if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
-                this.container.find('input[name=daterangepicker_start]').val(date.format(this.locale.format));
-            } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
-                this.container.find('input[name=daterangepicker_end]').val(date.format(this.locale.format));
-            }
-
             //highlight the dates between the start date and the date being hovered as a potential end date
             var leftCalendar = this.leftCalendar;
             var rightCalendar = this.rightCalendar;


### PR DESCRIPTION
Users find the change on hover to be confusing. Because they have already made a selection, they think the dates are changing from the hover and they do not realize clicking apply will use the selected dates. Removing these lines allows updating the dates only when selected by the user.