### PR TITLE
Include moment.js only if it does not already exist in window.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -20,7 +20,7 @@
             jQuery = require('jquery');
             if (!jQuery.fn) jQuery.fn = {};
         }
-        var moment = (typeof window != 'undefined') ? window.moment : require('moment');
+        var moment = (typeof window != 'undefined' && typeof window.moment != 'undefined') ? window.moment : require('moment');
         module.exports = factory(moment, jQuery);
     } else {
         // Browser globals

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -20,7 +20,8 @@
             jQuery = require('jquery');
             if (!jQuery.fn) jQuery.fn = {};
         }
-        module.exports = factory(require('moment'), jQuery);
+        var moment = (typeof window != 'undefined') ? window.moment : require('moment');
+        module.exports = factory(moment, jQuery);
     } else {
         // Browser globals
         root.daterangepicker = factory(root.moment, root.jQuery);


### PR DESCRIPTION
Some applications may have an odd-ball configuration set up with SystemJS or whatever there module loader could be and already have moment.js included and this prevents it from loading twice in those configurations.
This repeats the practice we're already doing with loading JQuery. 