### PR TITLE
This enables autoApply: false for singleDatePicker: true.  Basically …

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -238,8 +238,10 @@
 
         if (typeof options.singleDatePicker === 'boolean') {
             this.singleDatePicker = options.singleDatePicker;
-            if (this.singleDatePicker)
+            if (this.singleDatePicker) {
                 this.endDate = this.startDate.clone();
+                this.autoApply = true;
+            }
         }
 
         if (typeof options.timePicker === 'boolean')
@@ -382,8 +384,6 @@
             this.container.find('.daterangepicker_input input, .daterangepicker_input > i').hide();
             if (this.timePicker) {
                 this.container.find('.ranges ul').hide();
-            } else {
-                this.container.find('.ranges').hide();
             }
         }
 
@@ -1356,7 +1356,7 @@
 
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
-                if (!this.timePicker)
+                if (!this.timePicker && this.autoApply)
                     this.clickApply();
             }
 


### PR DESCRIPTION
…if you want to have empty values for your input fields but also use a singleDatePicker, this will allow it.  I check for autoApply: true before hiding the apply/cancel buttons (previously these were hidden always for singleDatePicker).  I only call the apply function on a date selection if autoApply is true.  I also set autoApply: true by default for singleDatePicker to try to minimize any impact for existing users who expect this behavior.