### PR TITLE
Update daterangepicker.js Line no. 391 & 1175

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -388,7 +388,7 @@
         }
 
         if ((typeof options.ranges === 'undefined' && !this.singleDatePicker) || this.alwaysShowCalendars) {
-            this.container.addClass('show-calendar');
+            this.container.addClass('show-calendar notranslate'); // 'notranslate' class is to solve issue of change date number to word (Ex. 11 To Eleven) when we use Google Tranlator to the website.
         }
 
         this.container.addClass('opens' + this.opens);
@@ -1172,7 +1172,7 @@
         },
 
         showCalendars: function() {
-            this.container.addClass('show-calendar');
+            this.container.addClass('show-calendar notranslate'); // 'notranslate' class is to solve issue of change date number to word (Ex. 11 To Eleven) when we use Google Tranlator to the website.
             this.move();
             this.element.trigger('showCalendar.daterangepicker', this);
         },


### PR DESCRIPTION
Need of class name 'notranslate' to the calender is that if any one use google translator on the website in chrome selecting English language (But website in other language-in my case Website in Spanish) and want to use calender then chrome change the Date Digits to the words like 11 To Eleven so we need to add class  'notranslate' suggested By google forum(https://cloud.google.com/translate/faq#technical) to stop a particular element from Translate(Sorry For my english).