### PR TITLE
Add data-date to the td elements

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -50,6 +50,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.dateFormatOnTd = 'YYYY-MM-DD HH:mm:00';
         this.ranges = {};
 
         this.opens = 'right';
@@ -271,7 +272,10 @@
 
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
-
+        
+        if (typeof options.dateFormatOnTd === 'string')
+            this.dateFormatOnTd = options.dateFormatOnTd;
+        
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -845,7 +849,7 @@
                     if (!disabled)
                         cname += 'available';
 
-                    html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '">' + calendar[row][col].date() + '</td>';
+                    html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '" data-date="'+calendar[row][col].format(this.dateFormatOnTd)+'">' + calendar[row][col].date() + '</td>';
 
                 }
                 html += '</tr>';


### PR DESCRIPTION
I would like to have the date in some sort of format on the td elements in the picker so I can use the date on events like mouseover.

People in the past solved this in complicated way like the link shows.
http://stackoverflow.com/questions/35906930/bootstrap-date-range-picker-get-current-date-the-mouse-is-hovering-over

Any thoughts?
