### PR TITLE
stub jquery.fn to fix webpack server rendering

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -10,6 +10,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Make globaly available as well
         define(['moment', 'jquery'], function (moment, jquery) {
+            if (!jquery.fn) jquery.fn = {}; // webpack server rendering
             return (root.daterangepicker = factory(moment, jquery));
         });
     } else if (typeof module === 'object' && module.exports) {


### PR DESCRIPTION
This fixes the same thing as #816 but for webpack (https://github.com/skratchdot/react-bootstrap-daterangepicker/issues/43)