### PR TITLE
Added an option to not dismiss the date-range picker when clicking outside of it

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -51,6 +51,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.dismissOnOutsideClick = true;
         this.ranges = {};
 
         this.opens = 'right';
@@ -272,6 +273,9 @@
 
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
+
+        if (typeof options.dismissOnOutsideClick === 'boolean')
+            this.dismissOnOutsideClick = options.dismissOnOutsideClick;
 
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
@@ -1099,18 +1103,20 @@
         show: function(e) {
             if (this.isShowing) return;
 
-            // Create a click proxy that is private to this instance of datepicker, for unbinding
-            this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
+            // Bind global datepicker mousedown for hiding unless option dismissOnOutsideClick is true
+            if (!this.dismissOnOutsideClick) {
+                // Create a click proxy that is private to this instance of datepicker, for unbinding
+                this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
 
-            // Bind global datepicker mousedown for hiding and
-            $(document)
-              .on('mousedown.daterangepicker', this._outsideClickProxy)
-              // also support mobile devices
-              .on('touchend.daterangepicker', this._outsideClickProxy)
-              // also explicitly play nice with Bootstrap dropdowns, which stopPropagation when clicking them
-              .on('click.daterangepicker', '[data-toggle=dropdown]', this._outsideClickProxy)
-              // and also close when focus changes to outside the picker (eg. tabbing between controls)
-              .on('focusin.daterangepicker', this._outsideClickProxy);
+                $(document)
+                  .on('mousedown.daterangepicker', this._outsideClickProxy)
+                  // also support mobile devices
+                  .on('touchend.daterangepicker', this._outsideClickProxy)
+                  // also explicitly play nice with Bootstrap dropdowns, which stopPropagation when clicking them
+                  .on('click.daterangepicker', '[data-toggle=dropdown]', this._outsideClickProxy)
+                  // and also close when focus changes to outside the picker (eg. tabbing between controls)
+                  .on('focusin.daterangepicker', this._outsideClickProxy);
+            }
 
             // Reposition the picker if the window is resized while it's open
             $(window).on('resize.daterangepicker', $.proxy(function(e) { this.move(e); }, this));

--- a/website/index.html
+++ b/website/index.html
@@ -516,6 +516,12 @@
                                 </label>
                               </div>
 
+                              <div class="checkbox">
+                                <label>
+                                  <input type="checkbox" id="dismissOnOutsideClick"> dismissOnOutsideClick
+                                </label>
+                              </div>
+
                             </div>
                             <div class="col-md-4">
 
@@ -680,6 +686,10 @@
                             <li>
                                 <code>parentEl</code>: (string) jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
                             </li>
+                            <li>
+                                <code>dismissOnOutsideClick</code>: (boolean) Indicates whether the date range picker should be dismissed when clicking outside of it.
+                            </li>
+
                         </ul>
 
                     </div>
@@ -741,6 +751,9 @@
                             </li>
                             <li>
                                 <code>cancel.daterangepicker</code>: Triggered when the cancel button is clicked
+                            </li>
+                            <li>
+                                <code>outsideClick.daterangepicker</code>: Triggered when the user clicks outside the date range picker. Please note that it won't be triggered if <code>dismissOnOutsideClick</code> is false.
                             </li>
                         </ul>
 

--- a/website/website.js
+++ b/website/website.js
@@ -90,6 +90,9 @@ $(document).ready(function() {
       if (!$('#autoUpdateInput').is(':checked'))
         options.autoUpdateInput = false;
 
+      if ($('#dismissOnOutsideClick').is(':checked'))
+        options.dismissOnOutsideClick = true;
+
       if (!$('#showCustomRangeLabel').is(':checked'))
         options.showCustomRangeLabel = false;
 


### PR DESCRIPTION
- New option appeared in the initializer, so we can now specify whether we want the date picker to be dismissed when clicking outside of it. 
It avoids hacks like that: 
```coffeescript
$("#my-daterange-picker").on 'show.daterangepicker', (e) ->
    # Trick to unbind the dismiss of the datepicker when clicking outside it
    $(document).off 'mousedown.daterangepicker'
    $(document).off 'touchend.daterangepicker'
    $(document).off 'click.daterangepicker'
    $(document).off 'focusin.daterangepicker'
```

- Updated the documentation to reflect that new option
- Updated the generator to be able to use that option in it
- added the `outsideClick.daterangepicker` event in the documentation, which was first introduced by #489 .