### PR TITLE
Add localization option for range's labels.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -75,7 +75,8 @@
             customRangeLabel: 'Custom Range',
             daysOfWeek: moment.weekdaysMin(),
             monthNames: moment.monthsShort(),
-            firstDay: moment.localeData().firstDayOfWeek()
+            firstDay: moment.localeData().firstDayOfWeek(),
+            ranges: {}
         };
 
         this.callback = function() { };
@@ -169,6 +170,9 @@
                 var rangeHtml = elem.value;
                 this.locale.customRangeLabel = rangeHtml;
             }
+
+            if (typeof options.locale.ranges === 'object')
+                this.locale.ranges = options.locale.ranges;
         }
         this.container.addClass(this.locale.direction);
 
@@ -332,7 +336,7 @@
 
                 // If the end of the range is before the minimum or the start of the range is
                 // after the maximum, don't display this range option at all.
-                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day')) 
+                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day'))
                   || (maxDate && start.isAfter(maxDate, this.timepicker ? 'minute' : 'day')))
                     continue;
 
@@ -346,7 +350,8 @@
 
             var list = '<ul>';
             for (range in this.ranges) {
-                list += '<li data-range-key="' + range + '">' + range + '</li>';
+                var rangeLabel = this.locale.ranges[range] || range;
+                list += '<li data-range-key="' + range + '">' + rangeLabel + '</li>';
             }
             if (this.showCustomRangeLabel) {
                 list += '<li data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
@@ -1530,7 +1535,7 @@
             this.container.find('input[name="daterangepicker_start"], input[name="daterangepicker_end"]').removeClass('active');
             $(e.target).addClass('active');
 
-            // Set the state such that if the user goes back to using a mouse, 
+            // Set the state such that if the user goes back to using a mouse,
             // the calendars are aware we're selecting the end of the range, not
             // the start. This allows someone to edit the end of a date range without
             // re-selecting the beginning, by clicking on the end date input then


### PR DESCRIPTION
Hi 

I add support for localize range's labels by using `opts.locale.ranges` option. 

### Motivation

In my project I need to store value of range in relative form ('Today', etc.), but the site supports multiple languages. So It would be nice to use labels as keys of ranges in relative forms, not as localized labels for users. Therefore I add new option for range's labels localization, see Usage below.

## Usage:

```javascript
$('input[name="daterange"]').daterangepicker(
{
  // ...
  ranges: {
    'today': [moment(), moment()],
    'yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
    'last7Days': [moment().subtract(6, 'days'), moment()],
    'last30Days': [moment().subtract(29, 'days'), moment()],
    'thisMonth': [moment().startOf('month'), moment().endOf('month')],
    'lastMonth': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
  },
  locale: {
    // ...
    ranges: {
      'today': 'Today',
      'yesterday': 'Yesterday',
      'last7Days': 'Last 7 Days',
      'last30Days': 'Last 30 Days',
      'thisMonth': 'This Month',
      'lastMonth': 'Last Month'
    }
  }
}, 
function(start, end, label) { });
```

If user doesn't provide ranges locale option, original labels are used (library works as before, https://github.com/feki/bootstrap-daterangepicker/blob/feature/add-localization-of-ranges-labels/daterangepicker.js#L353). 