### PR TITLE
Ensure that pressing the 'enter' key in the daterange inputs leads to consistent behaviour across major browsers

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -424,7 +424,8 @@
             .on('click.daterangepicker', '.daterangepicker_input input', $.proxy(this.showCalendars, this))
             .on('focus.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsFocused, this))
             .on('blur.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsBlurred, this))
-            .on('change.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsChanged, this));
+            .on('change.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsChanged, this))
+            .on('keydown.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsKeydown, this));
 
         this.container.find('.ranges')
             .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
@@ -1561,6 +1562,19 @@
             }
 
         },
+
+        formInputsKeydown: function(e) {
+            // This function ensures that if the 'enter' key was pressed in the input, then the calendars
+            // are updated with the startDate and endDate.
+            // This behaviour is automatic in Chrome/Firefox/Edge but not in IE 11 hence why this exists.
+            // Other browsers and versions of IE are untested and the behaviour is unknown.
+            if (e.keyCode === 13) {
+                // Prevent the calendar from being updated twice on Chrome/Firefox/Edge
+                e.preventDefault(); 
+                this.formInputsChanged(e);
+            }
+        },
+
 
         elementChanged: function() {
             if (!this.element.is('input')) return;


### PR DESCRIPTION
When you enter a date in the start/end date inputs and you press the 'enter' key, the calendar would then update with the range specified in the inputs. This works in Chrome/Firefox/Edge but not in IE 11. This change is to make this behaviour consistent across these major browsers.
As to the cause of this issue, I think it's down to the different browsers triggering the onChange event for inputs on different things. It seems that Chrome/Firefox/Edge will trigger the event when the 'enter' key is pressed as well as when the focus is lost on the input. Whereas IE 11 would only trigger the onChange event when focus is lost on the input. 

I know that this may be a bit specific of a change for IE 11 (which admittedly is because we need to support it for our clients), but this change means that we no longer need to know (or care) which 
browsers trigger the onChange event on the 'enter' key press. 