### PR TITLE
Enable to use format like 'YYYY MM' at calendar month

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -75,7 +75,8 @@
             customRangeLabel: 'Custom Range',
             daysOfWeek: moment.weekdaysMin(),
             monthNames: moment.monthsShort(),
-            firstDay: moment.localeData().firstDayOfWeek()
+            firstDay: moment.localeData().firstDayOfWeek(),
+            monthFollowsYear: false
         };
 
         this.callback = function() { };
@@ -169,6 +170,9 @@
                 var rangeHtml = elem.value;
                 this.locale.customRangeLabel = rangeHtml;
             }
+
+            if (typeof options.locale.monthFollowsYear === 'boolean')
+                this.locale.monthFollowsYear = options.locale.monthFollowsYear;
         }
         this.container.addClass(this.locale.direction);
 
@@ -713,7 +717,12 @@
                 html += '<th></th>';
             }
 
-            var dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
+            var dateHtml;
+            if (this.locale.monthFollowsYear) {
+                dateHtml = calendar[1][1].format("YYYY ") + this.locale.monthNames[calendar[1][1].month()];
+            } else {
+                dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
+            }
 
             if (this.showDropdowns) {
                 var currentMonth = calendar[1][1].month();
@@ -745,7 +754,7 @@
                 }
                 yearHtml += '</select>';
 
-                dateHtml = monthHtml + yearHtml;
+                dateHtml = this.locale.monthFollowsYear ? yearHtml + monthHtml : monthHtml + yearHtml;
             }
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';

--- a/demo.html
+++ b/demo.html
@@ -308,7 +308,8 @@
               customRangeLabel: 'Custom',
               daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
               monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-              firstDay: 1
+              firstDay: 1,
+              monthFollowsYear: false
             };
           } else {
             $('#rtl-wrap').hide();

--- a/example/amd/main.js
+++ b/example/amd/main.js
@@ -88,7 +88,8 @@ $(document).ready(function() {
         customRangeLabel: 'Custom',
         daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
         monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-        firstDay: 1
+        firstDay: 1,
+        monthFollowsYear: false
       };
     }
 

--- a/example/browserify/main.js
+++ b/example/browserify/main.js
@@ -83,7 +83,8 @@ $(document).ready(function() {
         customRangeLabel: 'Custom',
         daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
         monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-        firstDay: 1
+        firstDay: 1,
+        monthFollowsYear: false
       };
     }
 

--- a/website/website.js
+++ b/website/website.js
@@ -80,7 +80,8 @@ $(document).ready(function() {
           weekLabel: 'W',
           daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
           monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-          firstDay: 1
+          firstDay: 1,
+          monthFollowsYear: false
         };
       }
 


### PR DESCRIPTION
As a date format like 'YYYY MM' is more popular than 'MM YYYY' in some languages such as Japanese and Chinese, I added a locale option to enable use the format.

I hope you review and merge this PR ;)