### PR TITLE
Protection from bad values in connected field

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -637,6 +637,14 @@
             var hour = calendar.month.hour();
             var minute = calendar.month.minute();
             var second = calendar.month.second();
+
+            //protection from bad field values
+            month = isNaN(month)?moment().month():month;
+            year = isNaN(year)?moment().year():year;
+            hour = isNaN(hour)?moment().hour():hour;
+            minute = isNaN(minute)?moment().minute():minute;
+            second = isNaN(second)?moment().second():second;
+
             var daysInMonth = moment([year, month]).daysInMonth();
             var firstDay = moment([year, month, 1]);
             var lastDay = moment([year, month, daysInMonth]);


### PR DESCRIPTION
If the connected field has bad values (00/00/2000) in it, the calendar fails rendering; this little check makes the calendar render correctly and all goes well.