### PR TITLE
Alternative mode for selecting date ranges

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -562,15 +562,18 @@
 
                 //if both dates are visible already, do nothing
                 if (!this.singleDatePicker && this.leftCalendar.month && this.rightCalendar.month &&
-                    (this.startDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM') || this.startDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM'))
+                    (this.startDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM') || (!this.endpointCalendars && this.startDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM')))
                     &&
-                    (this.endDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM') || this.endDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM'))
+                    (this.endDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM') || (!this.endpointCalendars && this.endDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM')))
                     ) {
                     return;
                 }
 
                 this.leftCalendar.month = this.startDate.clone().date(2);
-                if (!this.linkedCalendars && (this.endDate.month() != this.startDate.month() || this.endDate.year() != this.startDate.year())) {
+                if (this.endpointCalendars) {
+                    this.leftCalendar.month = this.startDate.clone().date(2);
+                    this.rightCalendar.month = this.endDate.clone().date(2);
+                } else if (!this.linkedCalendars && this.endDate.month() != this.startDate.month() || this.endDate.year() != this.startDate.year()) {
                     this.rightCalendar.month = this.endDate.clone().date(2);
                 } else {
                     this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1268,18 +1268,28 @@
             var col = title.substr(3, 1);
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
+            var startInput = this.container.find('input[name=daterangepicker_start]');
+            var endInput =  this.container.find('input[name=daterangepicker_end]');
 
             var input = null;
             if (this.endpointCalendars) {
-                if (cal.hasClass('left') && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
-                  input = this.container.find('input[name=daterangepicker_start]');
-                } else if (cal.hasClass('right') && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
-                  input = this.container.find('input[name=daterangepicker_end]');
+                if (cal.hasClass('left') && !startInput.is(":focus")) {
+                  input = startInput;
+                  if (!endInput.is(":focus")) {
+                    endInput.removeClass('active');
+                    startInput.addClass('active');
+                  }
+                } else if (cal.hasClass('right') && !endInput.is(":focus")) {
+                  input = endInput;
+                  if (!startInput.is(":focus")) {
+                    startInput.removeClass('active');
+                    endInput.addClass('active');
+                  }
                 }
-            } else if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
-                input = this.container.find('input[name=daterangepicker_start]');
-            } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
-                input = this.container.find('input[name=daterangepicker_end]');
+            } else if (this.endDate && !startInput.is(":focus")) {
+                input = startInput;
+            } else if (!this.endDate && !endInput.is(":focus")) {
+                input = endInput;
             }
 
             if (input) {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1271,9 +1271,9 @@
 
             var input = null;
             if (this.endpointCalendars) {
-                if (cal.hasClass('left')) {
+                if (cal.hasClass('left') && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
                   input = this.container.find('input[name=daterangepicker_start]');
-                } else {
+                } else if (cal.hasClass('right') && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
                   input = this.container.find('input[name=daterangepicker_end]');
                 }
             } else if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
@@ -1561,7 +1561,7 @@
             // re-selecting the beginning, by clicking on the end date input then
             // using the calendar.
             var isRight = $(e.target).closest('.calendar').hasClass('right');
-            if (isRight) {
+            if (isRight && !this.endpointCalendars) {
                 this.endDate = null;
                 this.setStartDate(this.startDate.clone());
                 this.updateView();

--- a/demo.html
+++ b/demo.html
@@ -137,6 +137,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="endpointCalendars"> endpointCalendars
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 
@@ -325,6 +331,9 @@
 
           if ($('#alwaysShowCalendars').is(':checked'))
             options.alwaysShowCalendars = true;
+
+          if ($('#endpointCalendars').is(':checked'))
+            options.endpointCalendars = true;
 
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();

--- a/example/amd/index.html
+++ b/example/amd/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="endpointCalendars"> endpointCalendars
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/amd/main.js
+++ b/example/amd/main.js
@@ -101,6 +101,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#endpointCalendars').is(':checked'))
+      options.endpointCalendars = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/example/browserify/index.html
+++ b/example/browserify/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="endpointCalendars"> endpointCalendars
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/browserify/main.js
+++ b/example/browserify/main.js
@@ -96,6 +96,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#endpointCalendars').is(':checked'))
+      options.endpointCalendars = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/website/website.js
+++ b/website/website.js
@@ -96,6 +96,9 @@ $(document).ready(function() {
       if ($('#alwaysShowCalendars').is(':checked'))
         options.alwaysShowCalendars = true;
 
+      if ($('#endpointCalendars').is(':checked'))
+        options.endpointCalendars = true;
+
       if ($('#parentEl').val().length)
         options.parentEl = $('#parentEl').val();
 


### PR DESCRIPTION
Added a new configuration flag (now named `endpointCalendars`) that changes the default date range selection behavior as follows:
- The left calendar always selects (or moves) the start date and hovering over the left calendar is reflected in the start date input (unless the input is focused).
- The right calendar does the same for the end date.

We need this new mode because some users consider the default behavior confusing and have requested this new functionality. Obviously, we don't want to break the default functionality which is why the new mode is behind a configuration flag that needs to be explicitly enabled.

The new mode doesn't play well with the `linkedCalendars` flag but I think it makes little sense to use the two flags together.

This pull request also eliminates some repetitive code.