### PR TITLE
Added keyboard navigation

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,6 +1,7 @@
 /**
-* @version: 2.1.25
+* @version: 2.1.26
 * @author: Dan Grossman http://www.dangrossman.info/
+* @author: Rich Rein (contributed keyboard navigation
 * @copyright: Copyright (c) 2012-2017 Dan Grossman. All rights reserved.
 * @license: Licensed under the MIT license. See http://www.opensource.org/licenses/mit-license.php
 * @website: http://www.daterangepicker.com/
@@ -76,7 +77,22 @@
             daysOfWeek: moment.weekdaysMin(),
             monthNames: moment.monthsShort(),
             firstDay: moment.localeData().firstDayOfWeek()
-        };
+        };        
+
+    	this.keys = {
+			tab: 9,
+			enter: 13,
+			esc: 27,
+			space: 32,
+			pageup: 33,
+			pagedown: 34,
+			end: 35,
+			home: 36,
+			left: 37,
+			up: 38,
+			right: 39,
+			down: 40
+		};
 
         this.callback = function() { };
 
@@ -346,10 +362,10 @@
 
             var list = '<ul>';
             for (range in this.ranges) {
-                list += '<li data-range-key="' + range + '">' + range + '</li>';
+                list += '<li tabindex="-1" data-range-key="' + range + '">' + range + '</li>';
             }
             if (this.showCustomRangeLabel) {
-                list += '<li data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
+                list += '<li tabindex="-1" data-range-key="' + this.locale.customRangeLabel + '">' + this.locale.customRangeLabel + '</li>';
             }
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
@@ -437,17 +453,29 @@
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),
-                'keyup.daterangepicker': $.proxy(this.elementChanged, this),
-                'keydown.daterangepicker': $.proxy(this.keydown, this)
+                'keyup.daterangepicker': $.proxy(this.elementChanged, this)
             });
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
         }
+        
+        this.container
+        	// tab should apply to the entire container
+        	.on('keydown.daterangepicker', $.proxy(this.handleTabNavigationKeyDown, this))
+        	.on('keypress.daterangepicker', $.proxy(this.handleGridKeyPress, this))
+        	// specific elements have specific keyboard shortcuts 
+        	.on('keydown.daterangepicker', 'td', $.proxy(this.handleGridKeyDown, this))
+        	.on('keypress.daterangepicker', 'td', $.proxy(this.handleGridKeyPress, this))
+        	.on('keydown.daterangepicker', '.prev', $.proxy(this.handleGridKeyDown, this))
+        	.on('keypress.daterangepicker', '.prev', $.proxy(this.handleGridKeyPress, this))
+        	.on('keydown.daterangepicker', '.next', $.proxy(this.handleGridKeyDown, this))
+        	.on('keypress.daterangepicker', '.next', $.proxy(this.handleGridKeyPress, this))
+        	.on('keydown.daterangepicker', 'li', $.proxy(this.handleGridKeyDown, this))
+        	.on('keypress.daterangepicker', 'li', $.proxy(this.handleGridKeyPress, this));
 
         //
         // if attached to a text input, set the initial value
         //
-
         if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
             this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
             this.element.trigger('change');
@@ -455,7 +483,6 @@
             this.element.val(this.startDate.format(this.locale.format));
             this.element.trigger('change');
         }
-
     };
 
     DateRangePicker.prototype = {
@@ -708,7 +735,7 @@
                 html += '<th></th>';
 
             if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
-                html += '<th class="prev available"><i class="fa fa-' + arrow.left + ' glyphicon glyphicon-' + arrow.left + '"></i></th>';
+                html += '<th class="prev available"><i class="fa fa-' + arrow.left + ' glyphicon glyphicon-' + arrow.left + '" tabindex="0" id="prev_mo"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -750,7 +777,7 @@
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
-                html += '<th class="next available"><i class="fa fa-' + arrow.right + ' glyphicon glyphicon-' + arrow.right + '"></i></th>';
+                html += '<th class="next available"><i class="fa fa-' + arrow.right + ' glyphicon glyphicon-' + arrow.right + '" tabindex="0" id="next_mo"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -790,7 +817,9 @@
 
                 for (var col = 0; col < 7; col++) {
 
-                    var classes = [];
+                    var classes = ['day'];
+                    var tabindex = '-1';
+                    var elId = 'calendar_' + side + '-row_' + row + '-day_' + col;
 
                     //highlight today's date
                     if (calendar[row][col].isSame(new Date(), "day"))
@@ -817,12 +846,20 @@
                         classes.push('off', 'disabled');
 
                     //highlight the currently selected start date
-                    if (calendar[row][col].format('YYYY-MM-DD') == this.startDate.format('YYYY-MM-DD'))
+                    if (calendar[row][col].format('YYYY-MM-DD') == this.startDate.format('YYYY-MM-DD')) {
                         classes.push('active', 'start-date');
+                    	if (side === 'left') {
+                    		tabindex = 0;
+                    	}
+                    }
 
                     //highlight the currently selected end date
-                    if (this.endDate != null && calendar[row][col].format('YYYY-MM-DD') == this.endDate.format('YYYY-MM-DD'))
-                        classes.push('active', 'end-date');
+                    if (this.endDate != null && calendar[row][col].format('YYYY-MM-DD') == this.endDate.format('YYYY-MM-DD')) {
+                        classes.push('active', 'end-date'); 
+                    	if (side === 'right') {               		
+                    		tabindex = 0;
+                    	}
+                    }
 
                     //highlight dates in-between the selected dates
                     if (this.endDate != null && calendar[row][col] > this.startDate && calendar[row][col] < this.endDate)
@@ -846,7 +883,7 @@
                     if (!disabled)
                         cname += 'available';
 
-                    html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '">' + calendar[row][col].date() + '</td>';
+                    html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '" tabindex="' + tabindex + '" id="' + elId + '">' + calendar[row][col].date() + '</td>';
 
                 }
                 html += '</tr>';
@@ -1124,6 +1161,13 @@
             this.move();
             this.element.trigger('show.daterangepicker', this);
             this.isShowing = true;
+            
+            // pass focus to calendar
+            if (this.container.find('.active.start-date').filter(':visible').length) {
+            	this.container.find('.active.start-date').focus();
+            } else if (this.container.find('li.active').filter(':visible').length) {
+            	this.container.find('li.active').focus();
+            }
         },
 
         hide: function(e) {
@@ -1371,18 +1415,19 @@
         calculateChosenLabel: function () {
             var customRange = true;
             var i = 0;
+            this.container.find('.ranges li').attr('tabindex', '-1');
             for (var range in this.ranges) {
                 if (this.timePicker) {
                     if (this.startDate.isSame(this.ranges[range][0]) && this.endDate.isSame(this.ranges[range][1])) {
                         customRange = false;
-                        this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').html();
+                        this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').attr('tabindex', '0').html();
                         break;
                     }
                 } else {
                     //ignore times when comparing dates if time picker is not enabled
                     if (this.startDate.format('YYYY-MM-DD') == this.ranges[range][0].format('YYYY-MM-DD') && this.endDate.format('YYYY-MM-DD') == this.ranges[range][1].format('YYYY-MM-DD')) {
                         customRange = false;
-                        this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').html();
+                        this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').attr('tabindex', '0').html();
                         break;
                     }
                 }
@@ -1390,7 +1435,7 @@
             }
             if (customRange) {
                 if (this.showCustomRangeLabel) {
-                    this.chosenLabel = this.container.find('.ranges li:last').addClass('active').html();
+                    this.chosenLabel = this.container.find('.ranges li:last').addClass('active').attr('tabindex', '0').html();
                 } else {
                     this.chosenLabel = null;
                 }
@@ -1587,12 +1632,348 @@
             this.setEndDate(end);
             this.updateView();
         },
+        
+        handleGridKeyDown: function(e) { // return false if handling event on our own, true if propagating elsewhere  
+        	var currentlySelectedDate;
+        	var newDateToSelect;
+        	        	
+        	if (e.target.className.includes('day')) {	        	
+        		var gridParts = e.target.id.split('-');
+	        	var cal = gridParts[0].split('_')[1];
+	        	var row = gridParts[1].split('_')[1];
+	        	var col = gridParts[2].split('_')[1];
+	        	currentlySelectedDate = cal === 'left' ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
+        	} else if (e.target.className.includes('prev') || e.target.className.includes('fa-chevron-left')) {
+        		currentlySelectedDate = this.endDate ? this.endDate : this.startDate;
+    		} else if (e.target.className.includes('next') || e.target.className.includes('fa-chevron-right')) {
+        		currentlySelectedDate = this.endDate ? this.endDate : this.startDate;
+    		}        	
 
-        keydown: function(e) {
-            //hide on tab or enter
-            if ((e.keyCode === 9) || (e.keyCode === 13)) {
-                this.hide();
+        	newDateToSelect = currentlySelectedDate;
+    		
+        	// ignore keys pressed while the alt key is also depressed
+    		if (e.altKey) {
+    			return true;
+    		}
+    		
+    		// react based upon key pressed
+    		switch (e.keyCode) {
+				// one day before the current selection
+    			case this.keys.left:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+	    				newDateToSelect = currentlySelectedDate.subtract(1, 'days');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// one day after the current selection
+    			case this.keys.right:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+    	    			newDateToSelect = currentlySelectedDate.add(1, 'days');
+        				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);    				
+    					e.stopPropagation();
+    					return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// one week before the current selection
+    			case this.keys.up:
+				{
+    	    		if (e.target.className.includes('day')) {
+        				// handle day by day navigation
+    	    			newDateToSelect = currentlySelectedDate.subtract(7, 'days');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else if (e.target.tagName === 'LI') {
+    	    			// move up through the ranges
+    	    			var selected = this.container.find("li.active");
+    	    		    $('li').removeClass('active');
+
+    	    		    // if there is no element before the selected one, we select the last one
+	    		    	selected.attr('tabindex','-1');
+    	    		    if (selected.prev().length == 0) {
+    	    		        selected.siblings().last().addClass('active').attr('tabindex','0').focus();
+    	    		    } else { // otherwise we just select the previous one
+    	    		        selected.prev().addClass('active').attr('tabindex','0').focus();
+    	    		    }   
+						e.stopPropagation();
+						return false; 	    			
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// one week after the current selection
+    			case this.keys.down:
+				{
+    	    		if (e.target.className.includes('day')) {
+        				// handle day by day navigation
+    	    			newDateToSelect = currentlySelectedDate.add(7, 'days');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else if (e.target.tagName === 'LI') {
+    	    			// move up through the ranges
+    	    			var selected = this.container.find('li.active');
+    	    		    $('li').removeClass('active');
+
+    	    		    // if there is no element after the selected one, we select the first one
+	    		    	selected.attr('tabindex','-1');
+    	    		    if (selected.next().length == 0) {
+    	    		        selected.siblings().first().addClass('active').attr('tabindex','0').focus();
+    	    		    } else { // otherwise we just select the next one
+    	    		        selected.next().addClass('active').attr('tabindex','0').focus();
+    	    		    }
+						e.stopPropagation();
+						return false;
+        	    	} else {
+    	    			return true;
+    	    		}
+				}
+				// the first day of the month (based upon the current selection)
+    			case this.keys.home:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+    	    			newDateToSelect = currentlySelectedDate.startOf('month');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// the last day of the month (based upon the current selection)
+    			case this.keys.end:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+    	    			newDateToSelect = currentlySelectedDate.endOf('month');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// navigate backwards a month or a year at a time (dependent on addition of control key)
+    			case this.keys.pageup:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+    	    			if (e.shiftKey) {
+	    					// ctrl+pageup: the same day of the previous year (based upon the current selection)
+	    					newDateToSelect = currentlySelectedDate.subtract(1, 'years');
+	    				} else {
+	    					// pageup: the same day of the previous month (based upon the current selection)
+	    					newDateToSelect = currentlySelectedDate.subtract(1, 'months');
+	    				}
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// navigate forward a month or a year at a time (dependent on addition of control key)
+    			case this.keys.pagedown:
+				{
+    				// handle day by day navigation
+    	    		if (e.target.className.includes('day')) {
+    	    			if (e.shiftKey) {
+	    					// ctrl+pageup: the same day of the next year (based upon the current selection)
+	    					newDateToSelect = currentlySelectedDate.add(1, 'years');
+	    				} else {
+	    					// pageup: the same day of the next month (based upon the current selection)
+	    					newDateToSelect = currentlySelectedDate.add(1, 'months');
+	    				}
+	    				newDateToSelect = currentlySelectedDate.add(1, 'months');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+				// select this date
+    			case this.keys.space:
+    			case this.keys.enter:
+				{
+    	    		if (e.target.className.includes('day')) {
+        				// handle day by day navigation
+    	    			this.clickDate(e);
+						e.stopPropagation();
+						return false;
+    	    		} else if (e.target.className.includes('prev') || e.target.className.includes('fa-chevron-left')) {
+    	    			// move back a month
+    	    			newDateToSelect = currentlySelectedDate.subtract(1, 'months');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else if (e.target.className.includes('next') || e.target.className.includes('fa-chevron-right')) {
+    	    			// move forward a month
+    	    			newDateToSelect = currentlySelectedDate.add(1, 'months');
+	    				this.updateSelectedDate(currentlySelectedDate, newDateToSelect);
+						e.stopPropagation();
+						return false;
+    	    		} else if (e.target.tagName === 'LI') {
+        				// select new range
+    	    			this.clickRange(e);
+						e.stopPropagation();
+						return false;
+    	    		} else {
+    	    			return true;
+    	    		}
+				}
+    		}
+    		return true;
+        },
+        
+        handleGridKeyPress: function(e) {
+        	// consume keypress events for browsers that use keypress to scroll the screen and manipulate tabs
+        	// return false if handling event on our own, true if propagating elsewhere
+    		if (e.altKey) {
+    			return true;
+    		}
+    		switch (e.keyCode) {
+    			case this.keys.tab:
+    			case this.keys.enter:
+    			case this.keys.space:
+    			case this.keys.esc:
+    			case this.keys.left:
+    			case this.keys.right:
+    			case this.keys.up:
+    			case this.keys.down:
+    			case this.keys.pageup:
+    			case this.keys.pagedown:
+    			case this.keys.home:
+    			case this.keys.end:
+    				{
+    					e.stopPropagation();
+    					return false;
+    				}
+    		}
+    		return true;
+    	},
+    	
+    	handleTabNavigationKeyDown: function(e) { // return false if handling event on our own, true if propagating elsewhere      		
+        	// ignore keys pressed while the alt key is also depressed
+    		if (e.altKey) {
+    			return true;
+    		}
+    		
+    		// react based upon key pressed
+    		switch (e.keyCode) {
+    			// close the date picker
+	    		case this.keys.esc:
+				{
+					// dismiss the dialog box
+					this.hide();
+					e.stopPropagation();
+					return false;
+				}
+				// navigate within the calendar
+    			case this.keys.tab:
+				{	
+    				// which sort of elements should count?
+    				var focusableElementsString = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex=0], *[contenteditable]";
+    				// Get list of focusable items
+    				var calendarItems = this.container.find("*");
+    			    var focusableItems = calendarItems.filter(focusableElementsString).filter(":visible");
+    			    // Get currently focused item
+    			    var focusedItem = $(":focus");
+    			    // Get the number of focusable items
+    			    var numberOfFocusableItems = focusableItems.length;
+    			    // Get the index of the currently focused item
+    			    var focusedItemIndex = focusableItems.index(focusedItem);
+    			    // If calendar doesn't contain focusable elements, ignore this
+    			    if (numberOfFocusableItems === 0) {
+						return true;
+    			    } else {
+    			    	// tab backwards
+    			        if (e.shiftKey) {
+    			        	// If focused on first item and user presses back-tab (or not yet focused within calendar), go to the last focusable item
+    			        	if (focusedItemIndex === -1 || focusedItemIndex === 0) {
+    			        		focusableItems.get(numberOfFocusableItems - 1).focus();
+    							e.stopPropagation();
+    							return false;
+    			        	}
+
+    			        } else {
+    			        	// If focused on the last item and user presses tab (or not yet focused within calendar), go to the first focusable item
+    			        	if (focusedItemIndex === -1 || focusedItemIndex == numberOfFocusableItems - 1) {
+    			        		focusableItems.get(0).focus();
+    							e.stopPropagation();
+    							return false;
+    			        	}
+    			        }
+    			    }
+				}
+    		}
+    		return true;
+    	},
+    	        
+        updateSelectedDate: function(oldDate, date) {        
+        	// TODO: Refactor this logic out, then reuse both here and clickDate()?
+        	var dateToFocus = 'start-date';
+
+            if (this.endDate || date.isBefore(this.startDate, 'day')) { //picking start
+                if (this.timePicker) {
+                    var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
+                    if (!this.timePicker24Hour) {
+                        var ampm = this.container.find('.left .ampmselect').val();
+                        if (ampm === 'PM' && hour < 12)
+                            hour += 12;
+                        if (ampm === 'AM' && hour === 12)
+                            hour = 0;
+                    }
+                    var minute = parseInt(this.container.find('.left .minuteselect').val(), 10);
+                    var second = this.timePickerSeconds ? parseInt(this.container.find('.left .secondselect').val(), 10) : 0;
+                    date = date.clone().hour(hour).minute(minute).second(second);
+                }
+                this.endDate = null;
+                this.setStartDate(date.clone());
+            } else if (!this.endDate && date.isBefore(this.startDate)) {
+                //special case: clicking the same date for start/end,
+                //but the time of the end date is before the start date
+                this.setEndDate(this.startDate.clone());
+            } else { // picking end
+            	dateToFocus = 'end-date';
+            	if (this.timePicker) {
+                    var hour = parseInt(this.container.find('.right .hourselect').val(), 10);
+                    if (!this.timePicker24Hour) {
+                        var ampm = this.container.find('.right .ampmselect').val();
+                        if (ampm === 'PM' && hour < 12)
+                            hour += 12;
+                        if (ampm === 'AM' && hour === 12)
+                            hour = 0;
+                    }
+                    var minute = parseInt(this.container.find('.right .minuteselect').val(), 10);
+                    var second = this.timePickerSeconds ? parseInt(this.container.find('.right .secondselect').val(), 10) : 0;
+                    date = date.clone().hour(hour).minute(minute).second(second);
+                }
+                this.setEndDate(date.clone());
             }
+
+            if (this.singleDatePicker) {
+                this.setEndDate(this.startDate);
+            }
+            
+            // re-render the calendar as appropriate
+            this.updateView();
+            if (this.startDate && this.endDate) {
+              this.updateElement();
+            }
+            // set focus on the date that they were manipulating
+            this.container.find('.' + dateToFocus).focus();
         },
 
         updateElement: function() {


### PR DESCRIPTION
## Keyboard interaction
### General
* <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> Navigates through the "focusable" items within the calendar pane. These items include date range labels, apply and cancel buttons, date/time inputs, and calendar grids - although only the currently selected start and end dates will accept focus (once a specific date has focus, use the keys specified in the next section to change which dates can accept/have focus).

### When focused on a specific date
* <kbd>Left</kbd> Move focus to the previous day. Will move to the last day of the previous month, if the current day is the first day of a month.
* <kbd>Right</kbd> Move focus to the next day. Will move to the first day of the following month, if the current day is the last day of a month.
* <kbd>Up</kbd> Move focus to the same day of the previous week. Will wrap to the appropriate day in the previous month.
* <kbd>Down</kbd> Move focus to the same day of the following week. Will wrap to the appropriate day in the following month.
* <kbd>PgUp</kbd> Move focus to the same date of the previous month. If that date does not exist, focus is placed on the last day of the month.
* <kbd>PgDn</kbd> Move focus to the same date of the following month. If that date does not exist, focus is placed on the last day of the month.
* <kbd>Shift+PgUp</kbd> Move focus to the same date of the previous year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
* <kbd>Shift+PgDn</kbd> Move focus to the same date of the following year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
* <kbd>Home</kbd> Move to the first day of the month.
* <kbd>End</kbd> Move to the last day of the month.
* <kbd>Enter</kbd> / <kbd>Space</kbd> Simulates a click on the highlighted date (in dual calendar mode, is aware of whether this should be the start or the end date).

### When focused on a navigational arrow
* <kbd>Enter</kbd> / <kbd>Space</kbd> Simulates a click on the highlighted navigational arrow.

### When focused on a date range label
* <kbd>Up</kbd> Move focus to the previous date range label (does not apply selection without user pressing enter/space). Will wrap back around to the bottom of the list if already at the top.
* <kbd>Down</kbd> Move focus to the next date range label (does not apply selection without user pressing enter/space). Will wrap back around to the top of the list if already at the bottom.
* <kbd>Enter</kbd> / <kbd>Space</kbd> Simulates a click on the highlighted date range (making the selection, and applying the range as appropriate).

### When focused on an action button
* <kbd>Enter</kbd> / <kbd>Space</kbd> Simulates a button click on the highlighted action button.