### PR TITLE
Fix for issue #1587

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -501,7 +501,7 @@
                 this.endDate = moment(endDate);
 
             if (!this.timePicker)
-                this.endDate = this.endDate.endOf('day');
+                this.endDate = this.endDate.add(1,'d').startOf('day').subtract(1,'second');
 
             if (this.timePicker && this.timePickerIncrement)
                 this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);


### PR DESCRIPTION
I realized this 'cause 15 oct 2017 was the first day of daylight saving time in Brazil and my app fails there.
I found the problem is because an issue with endOf('day') moment function (moment/moment#3132), that still open there.
So I figured out how to deal with it by myself work around with the logic in datarangepicker.js.