### PR TITLE
Keep time in ranges without timePicker

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -44,6 +44,7 @@
         this.showWeekNumbers = false;
         this.showISOWeekNumbers = false;
         this.showCustomRangeLabel = true;
+        this.timeInRanges = false;
         this.timePicker = false;
         this.timePicker24Hour = false;
         this.timePickerIncrement = 1;
@@ -242,6 +243,9 @@
             if (this.singleDatePicker)
                 this.endDate = this.startDate.clone();
         }
+        
+        if (typeof options.timeInRanges === 'boolean')
+            this.timeInRanges = options.timeInRanges;
 
         if (typeof options.timePicker === 'boolean')
             this.timePicker = options.timePicker;
@@ -1211,7 +1215,7 @@
                 this.startDate = dates[0];
                 this.endDate = dates[1];
 
-                if (!this.timePicker) {
+                if (!this.timePicker && !this.timeInRanges) {
                     this.startDate.startOf('day');
                     this.endDate.endOf('day');
                 }


### PR DESCRIPTION
I needed a way to keep the idea of having times associated with ranges but I didn't want to display the time picker. 

I think I have covered all of the cases I need to, let me know if I need to update the PR.