### PR TITLE
Update calculateChosenLabel to work with timepickerSeconds

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1372,8 +1372,10 @@
             var customRange = true;
             var i = 0;
             for (var range in this.ranges) {
-                if (this.timePicker) {
-                    if (this.startDate.isSame(this.ranges[range][0]) && this.endDate.isSame(this.ranges[range][1])) {
+              if (this.timePicker) {
+                    var format = this.timePickerSeconds ? "YYYY-MM-DD hh:mm:ss" : "YYYY-MM-DD hh:mm";
+                    //ignore times when comparing dates if time picker seconds is not enabled
+                    if (this.startDate.format(format) == this.ranges[range][0].format(format) && this.endDate.format(format) == this.ranges[range][1].format(format)) {
                         customRange = false;
                         this.chosenLabel = this.container.find('.ranges li:eq(' + i + ')').addClass('active').html();
                         break;


### PR DESCRIPTION
>options.timePicker does not allow second selection so calculatingChosenLabel did not work for labels with seconds
>Updated calculateChosenLabel so that it works with options.timePicker or option.timPickerSeconds enabled