### PR TITLE
Only define a global when AMD and CommonJS detection fail

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -11,7 +11,7 @@
         // AMD. Make globaly available as well
         define(['moment', 'jquery'], function (moment, jquery) {
             if (!jquery.fn) jquery.fn = {}; // webpack server rendering
-            return (root.daterangepicker = factory(moment, jquery));
+            return factory(moment, jquery);
         });
     } else if (typeof module === 'object' && module.exports) {
         // Node / Browserify


### PR DESCRIPTION
Only define a global when AMD and CommonJS detection fail.

This means that `daterangepicker` will no longer be available in the global namespace when the module is loaded by an AMD loader such as via RequireJS. This was already the case in CommonJS environments.

This is a breaking change for users AMD users who were relying on the global although that may be unlikely as the primary use case appears to be use as a jQuery plugin.

This enables proper isolation of dependencies and support for multiple versions of this library, for example as transitive dependencies of other libraries, to properly coexist.

Resolves #1578