### PR TITLE
Update daterangepicker.js

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1122,7 +1122,7 @@
             this.previousRightTime = this.endDate.clone();
 
             this.updateView();
-            this.container.show();
+            this.container.css({'display': 'flex'});
             this.move();
             this.element.trigger('show.daterangepicker', this);
             this.isShowing = true;


### PR DESCRIPTION
.show()  equivalent to   display: block.   firefox displays calendars (with date range) on a single column one on top of the other, while chrome does it on two columns (one next to the other). ' display: flex' fixes the issue and make both browsers display one next to the other.