### PR TITLE
Add option to allow selection of end date first

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -53,6 +53,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.allowEndDateFirst = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -276,6 +277,9 @@
 
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
+
+        if (typeof options.allowEndDateFirst === 'boolean')
+            this.allowEndDateFirst = options.allowEndDateFirst;
 
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
@@ -1260,8 +1264,7 @@
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             // * if one of the inputs above the calendars was focused, cancel that manual input
             //
-
-            if (this.endDate || date.isBefore(this.startDate, 'day')) { //picking start
+            if (this.endDate || date.isBefore(this.startDate, 'day')) {
                 if (this.timePicker) {
                     var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
                     if (!this.timePicker24Hour) {
@@ -1275,8 +1278,17 @@
                     var second = this.timePickerSeconds ? parseInt(this.container.find('.left .secondselect').val(), 10) : 0;
                     date = date.clone().hour(hour).minute(minute).second(second);
                 }
-                this.endDate = null;
-                this.setStartDate(date.clone());
+
+                if (date.isBefore(this.startDate, 'day') && this.allowEndDateFirst && !(this.startDate && this.endDate)) {
+                    // end date selected first
+                    this.setEndDate(this.startDate.clone());
+                    this.setStartDate(date.clone());
+                }
+                else
+                {
+                    this.endDate = null;
+                    this.setStartDate(date.clone());
+                }
             } else if (!this.endDate && date.isBefore(this.startDate)) {
                 //special case: clicking the same date for start/end,
                 //but the time of the end date is before the start date

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1283,6 +1283,11 @@
                     // end date selected first
                     this.setEndDate(this.startDate.clone());
                     this.setStartDate(date.clone());
+
+                    if (this.autoApply) {
+                      this.calculateChosenLabel();
+                      this.clickApply();
+                    }
                 }
                 else
                 {

--- a/demo.html
+++ b/demo.html
@@ -27,7 +27,7 @@
         <h1 style="margin: 0 0 20px 0">Configuration Builder</h1>
 
         <div class="well configurator">
-           
+
           <form>
           <div class="row">
 
@@ -141,6 +141,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="allowEndDateFirst"> allowEndDateFirst
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 
@@ -235,7 +241,7 @@
         $('#config-text').keyup(function() {
           eval($(this).val());
         });
-        
+
         $('.configurator input, .configurator select').change(function() {
           updateConfig();
         });
@@ -261,7 +267,7 @@
 
           if ($('#singleDatePicker').is(':checked'))
             options.singleDatePicker = true;
-          
+
           if ($('#showDropdowns').is(':checked'))
             options.showDropdowns = true;
 
@@ -273,7 +279,7 @@
 
           if ($('#timePicker').is(':checked'))
             options.timePicker = true;
-          
+
           if ($('#timePicker24Hour').is(':checked'))
             options.timePicker24Hour = true;
 
@@ -282,7 +288,7 @@
 
           if ($('#timePickerSeconds').is(':checked'))
             options.timePickerSeconds = true;
-          
+
           if ($('#autoApply').is(':checked'))
             options.autoApply = true;
 
@@ -331,15 +337,18 @@
           if ($('#alwaysShowCalendars').is(':checked'))
             options.alwaysShowCalendars = true;
 
+          if ($('#allowEndDateFirst').is(':checked'))
+            options.allowEndDateFirst = true;
+
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();
 
-          if ($('#startDate').val().length) 
+          if ($('#startDate').val().length)
             options.startDate = $('#startDate').val();
 
           if ($('#endDate').val().length)
             options.endDate = $('#endDate').val();
-          
+
           if ($('#minDate').val().length)
             options.minDate = $('#minDate').val();
 
@@ -364,7 +373,7 @@
           $('#config-text').val("$('#demo').daterangepicker(" + JSON.stringify(options, null, '    ') + ", function(start, end, label) {\n  console.log(\"New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')\");\n});");
 
           $('#config-demo').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); }).click();;
-          
+
         }
 
       });

--- a/example/amd/index.html
+++ b/example/amd/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="allowEndDateFirst"> allowEndDateFirst
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/amd/main.js
+++ b/example/amd/main.js
@@ -101,6 +101,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#allowEndDateFirst').is(':checked'))
+      options.allowEndDateFirst = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/example/browserify/index.html
+++ b/example/browserify/index.html
@@ -142,6 +142,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="allowEndDateFirst"> allowEndDateFirst
+                </label>
+              </div>
+
             </div>
             <div class="col-md-4">
 

--- a/example/browserify/main.js
+++ b/example/browserify/main.js
@@ -96,6 +96,9 @@ $(document).ready(function() {
     if ($('#alwaysShowCalendars').is(':checked'))
       options.alwaysShowCalendars = true;
 
+    if ($('#allowEndDateFirst').is(':checked'))
+      options.allowEndDateFirst = true;
+
     if ($('#parentEl').val().length)
       options.parentEl = $('#parentEl').val();
 

--- a/website/index.html
+++ b/website/index.html
@@ -263,7 +263,7 @@
                                     }, cb);
 
                                     cb(start, end);
-                                    
+
                                 });
                                 </script>
 
@@ -282,7 +282,7 @@
                             <div class="col-4">
                                 <label>Produces:</label>
                                 <input type="text" name="datefilter" class="form-control pull-right" value="" />
-                                 
+
                                 <script type="text/javascript">
                                 $(function() {
 
@@ -364,6 +364,9 @@
                             <code>alwaysShowCalendars</code>: (true/false) Normally, if you use the <code>ranges</code> option to specify pre-defined date ranges, calendars for choosing a custom date range are not shown until the user clicks "Custom Range". When this option is set to true, the calendars for choosing a custom date range are always shown instead.
                         </li>
                         <li>
+                            <code>allowEndDateFirst</code>: (true/false) Allows the end date to be selected before the start date.
+                        </li>
+                        <li>
                             <code>opens</code>: ('left'/'right'/'center') Whether the picker appears aligned to the left, to the right, or centered under the HTML element it's attached to.
                         </li>
                         <li>
@@ -416,14 +419,14 @@
                     <p>
                         You can programmatically update the <code>startDate</code> and <code>endDate</code>
                         in the picker using the <code>setStartDate</code> and <code>setEndDate</code> methods.
-                        You can access the Date Range Picker object and its functions and properties through 
+                        You can access the Date Range Picker object and its functions and properties through
                         data properties of the element you attached it to.
                     </p>
 
                     <script src="https://gist.github.com/dangrossman/8ff9b1220c9b5682e8bd.js"></script>
 
                     <br/>
-                    
+
                     <ul class="nobullets">
                         <li>
                             <code>setStartDate(Date or string)</code>: Sets the date range picker's currently selected start date to the provided date
@@ -482,7 +485,7 @@
                     <h1 style="margin-top: 30px"><a id="config" href="#config">Configuration Generator</a></h1>
 
                     <div class="well configurator">
-                                       
+
                       <form>
                           <div class="row">
 
@@ -737,7 +740,7 @@
         </script>
 
         <div id="footer">
-            Copyright &copy; 2012-2018 <a href="http://www.dangrossman.info/">Dan Grossman</a>. 
+            Copyright &copy; 2012-2018 <a href="http://www.dangrossman.info/">Dan Grossman</a>.
         </div>
 
     </body>


### PR DESCRIPTION
Added a boolean option that allows the control to be initialized with the ability to select an end date first.

Example: User selects January 15 (start date is set) and then selects January 10 (normally this would reset the start date to January 10). If the option `allowEndDateFirst` is set to true, the start date is set to January 10 and the end date is set to January 15.