### PR TITLE
Remove `table-condensed` class from table element for each month

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -690,7 +690,7 @@
             var selected = side == 'left' ? this.startDate : this.endDate;
             var arrow = this.locale.direction == 'ltr' ? {left: 'chevron-left', right: 'chevron-right'} : {left: 'chevron-right', right: 'chevron-left'};
 
-            var html = '<table class="table-condensed">';
+            var html = '<table>';
             html += '<thead>';
             html += '<tr>';
 


### PR DESCRIPTION
I suspect this was leftover from when Bootstrap was a dependency as it doesn't seem to be used by the library anywhere else.

If you happen to use this with Bootstrap < 4, it defines a `table-condensed` class which sets some padding on table cells, breaking the design, causing each calendar table to overflow it's container:
https://github.com/twbs/bootstrap/blob/v3.4.1/less/tables.less#L93-L104

This could be a breaking change if people customized their use of the library and relied on this class.