### PR TITLE
Add end-date class when calendar date is hovered in a range

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -198,10 +198,14 @@
 
 .daterangepicker td.start-date {
   border-radius: 4px 0 0 4px;
+  background-color: #357ebd;
+  color: #fff;
 }
 
 .daterangepicker td.end-date {
   border-radius: 0 4px 4px 0;
+  background-color: #357ebd;
+  color: #fff;
 }
 
 .daterangepicker td.start-date.end-date {
@@ -213,6 +217,12 @@
   border-color: transparent;
   color: #fff;
 }
+
+.daterangepicker td.start-date:hover, .daterangepicker td.end-date:hover {
+  background-color: #357ebd;
+  color: #fff;
+}
+
 
 .daterangepicker th.month {
   width: auto;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1282,6 +1282,11 @@
                     }
 
                 });
+
+                this.container.find('.drp-calendar tbody td').removeClass('end-date');
+                if (date.isAfter(startDate) || date.isSame(startDate, 'day')) {
+                    $(e.target).addClass('end-date');
+                }
             }
 
         },


### PR DESCRIPTION
It's not currently possible to target the end date in a range when it is hovered using CSS.

I've added an 'end-date' class which allows the table cell to be styled while selecting the end date of the date range.