### PR TITLE
Raise an event, so other layout can happen if needed

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1114,6 +1114,8 @@
                     });
                 }
             }
+			// Raise an event, so other layout can happen if needed
+            this.element.trigger('moved.daterangepicker', this);
         },
 
         show: function(e) {


### PR DESCRIPTION
Raise an event, so other layout can happen if needed

I've used this myself to move the picker back in the bounds of the scrollable page.
`
        ele.on('moved.daterangepicker', function (ev, picker) {
            let top = picker.container.offset().top;
            let height = picker.container.outerHeight();
            let windowHeight = $(window).height()
            if (top < 0) {
                $(picker.container).css({ top: '20px' });
            }
            else if (top + height > windowHeight) {
                $(picker.container).css({ top: `${windowHeight - height - 20}px` });
            }
        });`