### PR TITLE
Add autoHide option

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -55,6 +55,7 @@
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
         this.ranges = {};
+        this.autoHide = true;
 
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
@@ -1162,11 +1163,13 @@
             //if picker is attached to a text input, update it
             this.updateElement();
 
-            $(document).off('.daterangepicker');
-            $(window).off('.daterangepicker');
-            this.container.hide();
-            this.element.trigger('hide.daterangepicker', this);
-            this.isShowing = false;
+            if (this.autoHide) {
+                $(document).off('.daterangepicker');
+                $(window).off('.daterangepicker');
+                this.container.hide();
+                this.element.trigger('hide.daterangepicker', this);
+                this.isShowing = false;
+            }
         },
 
         toggle: function(e) {

--- a/website/index.html
+++ b/website/index.html
@@ -409,6 +409,9 @@
                         <li>
                             <code>parentEl</code>: (string) jQuery selector of the parent element that the date range picker will be added to, if not provided this will be 'body'
                         </li>
+                        <li>
+                            <code>autoHide</code>: (true/false) Hide the daterangepicker container after selection. Defaults to true
+                        </li>
                     </ul>
 
                     <h1 style="margin-top: 30px"><a id="methods" href="#methods">Methods</a></h1>


### PR DESCRIPTION
When set to false, the autoHide option disables the hide functionality so the daterangepicker can remain visible after selection

Closes #1824