### PR TITLE
Add month and year format option

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -71,6 +71,7 @@
         this.locale = {
             direction: 'ltr',
             format: moment.localeData().longDateFormat('L'),
+            monthFormat: null,
             separator: ' - ',
             applyLabel: 'Apply',
             cancelLabel: 'Cancel',
@@ -130,6 +131,9 @@
 
             if (typeof options.locale.format === 'string')
                 this.locale.format = options.locale.format;
+
+            if (typeof options.locale.monthFormat === 'string')
+                this.locale.monthFormat = options.locale.monthFormat;
 
             if (typeof options.locale.separator === 'string')
                 this.locale.separator = options.locale.separator;
@@ -705,6 +709,8 @@
             }
 
             var dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
+            if(this.locale.monthFormat !== null)
+                dateHtml = calendar[1][1].format(this.monthFormat);
 
             if (this.showDropdowns) {
                 var currentMonth = calendar[1][1].month();

--- a/demo.html
+++ b/demo.html
@@ -305,6 +305,7 @@
             options.locale = {
               direction: $('#rtl').is(':checked') ? 'rtl' : 'ltr',
               format: 'MM/DD/YYYY HH:mm',
+              monthFormat: 'MMMM YYYY',
               separator: ' - ',
               applyLabel: 'Apply',
               cancelLabel: 'Cancel',

--- a/example/amd/main.js
+++ b/example/amd/main.js
@@ -80,6 +80,7 @@ $(document).ready(function() {
     if ($('#locale').is(':checked')) {
       options.locale = {
         format: 'MM/DD/YYYY HH:mm',
+        monthFormat: 'MMMM YYYY',
         separator: ' - ',
         applyLabel: 'Apply',
         cancelLabel: 'Cancel',

--- a/example/browserify/main.js
+++ b/example/browserify/main.js
@@ -75,6 +75,7 @@ $(document).ready(function() {
     if ($('#locale').is(':checked')) {
       options.locale = {
         format: 'MM/DD/YYYY HH:mm',
+        monthFormat: 'MMMM YYYY',
         separator: ' - ',
         applyLabel: 'Apply',
         cancelLabel: 'Cancel',

--- a/website/website.js
+++ b/website/website.js
@@ -77,6 +77,7 @@ $(document).ready(function() {
       if ($('#locale').is(':checked')) {
         options.locale = {
           format: 'MM/DD/YYYY',
+          monthFormat: 'MMMM YYYY',
           separator: ' - ',
           applyLabel: 'Apply',
           cancelLabel: 'Cancel',


### PR DESCRIPTION
Added month and year format at the top of the calendar for localization.
In Japan, "2022/05" is used instead of "May 2022".