### PR TITLE
Fix #2319: pre-defined date ranges don't select AM/PM when selected

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1216,6 +1216,10 @@
                 if (!this.timePicker) {
                     this.startDate.startOf('day');
                     this.endDate.endOf('day');
+                } else {
+                    // set the AM/PM selectors to the pre-defined date ranges
+                    this.container.find('.drp-calendar.left .calendar-time .ampmselect').val(this.startDate.format('A'));
+                    this.container.find('.drp-calendar.right .calendar-time .ampmselect').val(this.endDate.format('A'));
                 }
 
                 if (!this.alwaysShowCalendars)


### PR DESCRIPTION
Fixes https://github.com/dangrossman/daterangepicker/discussions/2319

When selecting a pre-defined date range, if the time picker component is enabled we now select AM or PM based on the pre-defined dates. Previously, the AM/PM selection was not changed, which resulted in a display bug when rendering the DateRangePicker's UI after selecting a range which switches AM to PM or vice versa.