### PR TITLE
Added minSpan option

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -38,6 +38,7 @@
         this.endDate = moment().endOf('day');
         this.minDate = false;
         this.maxDate = false;
+        this.minSpan = false;
         this.maxSpan = false;
         this.autoApply = false;
         this.singleDatePicker = false;
@@ -206,6 +207,9 @@
         if (typeof options.cancelClass === 'string') //backwards compat
             this.cancelButtonClasses = options.cancelClass;
 
+        if (typeof options.minSpan === 'object')
+            this.minSpan = options.minSpan;
+
         if (typeof options.maxSpan === 'object')
             this.maxSpan = options.maxSpan;
 
@@ -332,6 +336,16 @@
                 var maxDate = this.maxDate;
                 if (this.maxSpan && maxDate && start.clone().add(this.maxSpan).isAfter(maxDate))
                     maxDate = start.clone().add(this.maxSpan);
+
+                // If minSpan exceeds maxSpan, use maxSpan instead.
+                if (this.minSpan && this.maxSpan && this.minSpan > this.maxSpan)
+                    this.minSpan = this.maxSpan;
+
+                // If end date does not equal or exceed start date + minSpan,
+                // use the start date + minSpan as end date.
+                if (this.minSpan && end.clone().isBefore(start.clone().add(this.minSpan).subtract(1, 'day').endOf('day')))
+                    end = start.clone().add(this.minSpan).subtract(1, 'day').endOf('day');
+
                 if (maxDate && end.isAfter(maxDate))
                     end = maxDate.clone();
 
@@ -496,6 +510,9 @@
 
             if (this.endDate.isBefore(this.startDate))
                 this.endDate = this.startDate.clone();
+
+            if (this.minSpan && this.endDate.clone().isBefore(this.startDate.clone().add(this.minSpan)))
+                this.endDate = this.startDate.clone().add(this.minSpan).subtract(1, 'day').endOf('day');
 
             if (this.maxDate && this.endDate.isAfter(this.maxDate))
                 this.endDate = this.maxDate.clone();


### PR DESCRIPTION
Added a minSpan option

If end date does not equal or exceed start date + minSpan, use the start date + minSpan as end date.

As safety measure if minSpan exceeds maxSpan, use maxSpan value for minSpan.