### PR TITLE
support for showSelectedDays option in custom range

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -92,7 +92,8 @@
   float: none;
 }
 
-.daterangepicker.single .drp-selected {
+.daterangepicker.single .drp-selected,
+.daterangepicker.single .drp-selected-dates {
   display: none;
 }
 
@@ -273,7 +274,8 @@
   vertical-align: middle;
 }
 
-.daterangepicker .drp-selected {
+.daterangepicker .drp-selected,
+.daterangepicker .drp-selected-dates {
   display: inline-block;
   font-size: 12px;
   padding-right: 8px;

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -54,6 +54,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.showSelectedDays = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -76,6 +77,7 @@
             cancelLabel: 'Cancel',
             weekLabel: 'W',
             customRangeLabel: 'Custom Range',
+            daysSelectedLabel: 'days selected',
             daysOfWeek: moment.weekdaysMin(),
             monthNames: moment.monthsShort(),
             firstDay: moment.localeData().firstDayOfWeek()
@@ -110,6 +112,7 @@
                     '<div class="calendar-time"></div>' +
                 '</div>' +
                 '<div class="drp-buttons">' +
+                    '<span class="drp-selected-dates"></span>' +
                     '<span class="drp-selected"></span>' +
                     '<button class="cancelBtn" type="button"></button>' +
                     '<button class="applyBtn" disabled="disabled" type="button"></button> ' +
@@ -158,6 +161,12 @@
                 elem.innerHTML = options.locale.customRangeLabel;
                 var rangeHtml = elem.value;
                 this.locale.customRangeLabel = rangeHtml;
+            }
+            if (typeof options.locale.daysSelectedLabel === 'string') {
+                var elem = document.createElement('textarea');
+                elem.innerHTML = options.locale.daysSelectedLabel;
+                var rangeHtml = elem.value;
+                this.locale.daysSelectedLabel = rangeHtml;
             }
         }
         this.container.addClass(this.locale.direction);
@@ -262,6 +271,9 @@
 
         if (typeof options.autoApply === 'boolean')
             this.autoApply = options.autoApply;
+
+        if (typeof options.showSelectedDays === 'boolean')
+            this.showSelectedDays = options.showSelectedDays
 
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
@@ -373,6 +385,9 @@
         //can't be used together for now
         if (this.timePicker && this.autoApply)
             this.autoApply = false;
+
+        if (this.timePicker && this.showSelectedDays)
+            this.showSelectedDays = false;
 
         if (this.autoApply) {
             this.container.addClass('auto-apply');
@@ -506,11 +521,18 @@
             this.previousRightTime = this.endDate.clone();
 
             this.container.find('.drp-selected').html(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            if (this.showSelectedDays) {
+                this.container.find('.drp-selected-dates').html(this.getTotalSelectedDates.call(this) + ' ' + this.locale.daysSelectedLabel);
+            }
 
             if (!this.isShowing)
                 this.updateElement();
 
             this.updateMonthsInView();
+        },
+
+        getTotalSelectedDates: function() {
+            return this.endDate.diff(this.startDate, 'days') + 1
         },
 
         isInvalidDate: function() {
@@ -531,8 +553,12 @@
                     this.container.find('.right .calendar-time select').prop('disabled', false).removeClass('disabled');
                 }
             }
-            if (this.endDate)
+            if (this.endDate) {
                 this.container.find('.drp-selected').html(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+                if (this.showSelectedDays) {
+                    this.container.find('.drp-selected-dates').html(this.getTotalSelectedDates.call(this) + ' ' + this.locale.daysSelectedLabel);
+                }
+            }
             this.updateMonthsInView();
             this.updateCalendars();
             this.updateFormInputs();

--- a/demo.html
+++ b/demo.html
@@ -162,6 +162,12 @@
                 </label>
               </div>
 
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" id="showSelectedDays"> showSelectedDays
+                </label>
+              </div>
+
               <div class="form-group">
                 <label for="opens">opens</label>
                 <select id="opens" class="form-control">
@@ -311,6 +317,7 @@
               fromLabel: 'From',
               toLabel: 'To',
               customRangeLabel: 'Custom',
+              daysSelectedLabel: 'selected days',
               daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
               monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
               firstDay: 1
@@ -327,6 +334,9 @@
 
           if (!$('#showCustomRangeLabel').is(':checked'))
             options.showCustomRangeLabel = false;
+
+          if ($('#showSelectedDays').is(':checked'))
+            options.showSelectedDays = true;
 
           if ($('#alwaysShowCalendars').is(':checked'))
             options.alwaysShowCalendars = true;

--- a/website/index.html
+++ b/website/index.html
@@ -361,6 +361,9 @@
                             This option will be highlighted whenever the current date range selection does not match one of the predefined ranges. Clicking it will display the calendars to select a new range.
                         </li>
                         <li>
+                            <code>showSelectedDays</code>: (true/false) Displays the total selected days when "Custom Range" option is selected.
+                        </li>
+                        <li>
                             <code>alwaysShowCalendars</code>: (true/false) Normally, if you use the <code>ranges</code> option to specify pre-defined date ranges, calendars for choosing a custom date range are not shown until the user clicks "Custom Range". When this option is set to true, the calendars for choosing a custom date range are always shown instead.
                         </li>
                         <li>
@@ -642,6 +645,12 @@
                               <div class="checkbox">
                                 <label>
                                   <input type="checkbox" id="showCustomRangeLabel" checked="checked"> showCustomRangeLabel
+                                </label>
+                              </div>
+
+                              <div class="checkbox">
+                                <label>
+                                  <input type="checkbox" id="showSelectedDays" checked="checked"> showSelectedDays
                                 </label>
                               </div>
 

--- a/website/website.js
+++ b/website/website.js
@@ -83,6 +83,7 @@ $(document).ready(function() {
           fromLabel: 'From',
           toLabel: 'To',
           customRangeLabel: 'Custom',
+          daysSelectedLabel: 'Selected days',
           weekLabel: 'W',
           daysOfWeek: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr','Sa'],
           monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -98,6 +99,9 @@ $(document).ready(function() {
 
       if (!$('#showCustomRangeLabel').is(':checked'))
         options.showCustomRangeLabel = false;
+
+      if ($('#showSelectedDays').is(':checked'))
+        options.showSelectedDays = true;
 
       if ($('#alwaysShowCalendars').is(':checked'))
         options.alwaysShowCalendars = true;


### PR DESCRIPTION
Fix for #2364

Added a new optional feature option `showSelectedDays` for Custom Range option. This feature is by default hidden.
The label for this feature is customizable through locale options. 

Note: I have disabled this feature when timepicker is enabled. this is to ensure that we don't want to show the days in fractional value. However, I can add this option if desired.

![image](https://github.com/user-attachments/assets/6e45c016-8da5-4609-8d0b-4d07f3587ddb)
