### PR TITLE
Fix allowing selection of a calendar past maxDate when time is included

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -698,7 +698,7 @@
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th></th>';
 
-            if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
+            if ((!minDate || minDate.isBefore(calendar.firstDay, 'day')) && (!this.linkedCalendars || side == 'left')) {
                 html += '<th class="prev available"><span></span></th>';
             } else {
                 html += '<th></th>';
@@ -740,7 +740,7 @@
             }
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
-            if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
+            if ((!maxDate || maxDate.isAfter(calendar.lastDay, 'day')) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
                 html += '<th class="next available"><span></span></th>';
             } else {
                 html += '<th></th>';


### PR DESCRIPTION
If the max date has some time information there (accidentally or otherwise), then calendar was allowing skip to entire next month.

This might have come up only in the context of the `singleCalendar` PR / extension.

To recreate problem, set maxDate to end date of this month, but include a time component.